### PR TITLE
[FEAT] 가챠 이미지 등록, 수정, 삭제, 조회 구현

### DIFF
--- a/backend/src/main/java/com/gachi/gacha/server/common/domain/ImageFormat.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/domain/ImageFormat.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ImageType {
+public enum ImageFormat {
     PNG("image/png", "png"),
     JPG("image/jpeg", "jpg"),
     JPEG("image/jpeg", "jpeg"),

--- a/backend/src/main/java/com/gachi/gacha/server/common/domain/ImageType.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/domain/ImageType.java
@@ -1,4 +1,4 @@
-package com.gachi.gacha.server.store.domain;
+package com.gachi.gacha.server.common.domain;
 
 import java.util.Arrays;
 import lombok.Getter;

--- a/backend/src/main/java/com/gachi/gacha/server/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/exception/ErrorCode.java
@@ -31,6 +31,9 @@ public enum ErrorCode {
     STORE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "SIE01", "존재하지 않는 매장 사진입니다."),
     INVALID_STORE_IMAGE_POLICY(HttpStatus.BAD_REQUEST, "SIE02", "유효하지 않은 매장 사진입니다."),
 
+    // Image
+    INVALID_IMAGE_POLICY(HttpStatus.BAD_REQUEST, "IE001", "지원하지 않는 이미지 형식입니다."),
+
     // S3
     S3_IMAGE_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E01", "이미지 파일을 읽는 중 오류가 발생했습니다."),
     S3_IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E02", "이미지 업로드 중 오류가 발생했습니다."),

--- a/backend/src/main/java/com/gachi/gacha/server/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/exception/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode {
     // S3
     S3_IMAGE_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E01", "이미지 파일을 읽는 중 오류가 발생했습니다."),
     S3_IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E02", "이미지 업로드 중 오류가 발생했습니다."),
-    S3_IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E03", "이미지 삭제 중 오류가 발생했습니다.");
+    S3_IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E03", "이미지 삭제 중 오류가 발생했습니다."),
+    S3_IMAGE_MOVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E04", "이미지를 휴지통으로 이동하는 중 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/com/gachi/gacha/server/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/exception/ErrorCode.java
@@ -18,6 +18,10 @@ public enum ErrorCode {
     GACHA_NOT_FOUND(HttpStatus.NOT_FOUND, "GE001", "존재하지 않는 가챠입니다."),
     INVALID_GACHA_POLICY(HttpStatus.BAD_REQUEST, "GE002", "유효하지 않은 가챠 정책입니다."),
 
+    // Gacha Image
+    GACHA_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "GIE01", "존재하지 않는 가챠 사진입니다."),
+    INVALID_GACHA_IMAGE_POLICY(HttpStatus.BAD_REQUEST, "GIE02", "유효하지 않은 가챠 사진입니다."),
+
     // Store
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "SE001", "존재하지 않는 매장입니다."),
     INVALID_STORE_POLICY(HttpStatus.BAD_REQUEST, "SE002", "유효하지 않은 매장 정보입니다."),

--- a/backend/src/main/java/com/gachi/gacha/server/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/exception/ErrorCode.java
@@ -31,14 +31,12 @@ public enum ErrorCode {
     STORE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "SIE01", "존재하지 않는 매장 사진입니다."),
     INVALID_STORE_IMAGE_POLICY(HttpStatus.BAD_REQUEST, "SIE02", "유효하지 않은 매장 사진입니다."),
 
-    // Image
-    INVALID_IMAGE_POLICY(HttpStatus.BAD_REQUEST, "IE001", "지원하지 않는 이미지 형식입니다."),
-
     // S3
-    S3_IMAGE_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E01", "이미지 파일을 읽는 중 오류가 발생했습니다."),
-    S3_IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E02", "이미지 업로드 중 오류가 발생했습니다."),
-    S3_IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E03", "이미지 삭제 중 오류가 발생했습니다."),
-    S3_IMAGE_MOVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E04", "이미지를 휴지통으로 이동하는 중 오류가 발생했습니다.");
+    S3_IMAGE_INVALID_POLICY(HttpStatus.BAD_REQUEST, "S3E01", "지원하지 않는 이미지 형식입니다."),
+    S3_IMAGE_READ_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E02", "이미지 파일을 읽는 중 오류가 발생했습니다."),
+    S3_IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E03", "이미지 업로드 중 오류가 발생했습니다."),
+    S3_IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E04", "이미지 삭제 중 오류가 발생했습니다."),
+    S3_IMAGE_MOVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3E05", "이미지를 휴지통으로 이동하는 중 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageConfig.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageConfig.java
@@ -1,4 +1,4 @@
-package com.gachi.gacha.server.store.infra.config;
+package com.gachi.gacha.server.common.infra.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageType.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageType.java
@@ -1,0 +1,14 @@
+package com.gachi.gacha.server.common.infra.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageType {
+    STORE("매장", "store"),
+    GACHA("가챠", "gacha");
+
+    private final String label;
+    private final String folderName;
+}

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
@@ -1,8 +1,8 @@
 package com.gachi.gacha.server.common.infra.config;
 
-import com.gachi.gacha.server.common.exception.ErrorCode;
-import com.gachi.gacha.server.common.exception.InvalidValueException;
 import com.gachi.gacha.server.common.domain.ImageType;
+import com.gachi.gacha.server.common.exception.ErrorCode;
+import com.gachi.gacha.server.common.infra.exception.ImageInvalidValueException;
 import com.gachi.gacha.server.common.infra.exception.S3Exception;
 import java.io.IOException;
 import java.util.UUID;
@@ -104,7 +104,7 @@ public class ImageUploader {
      */
     private String validateContentType(final String contentType) {
         if (!ImageType.isAllowedContentType(contentType)) {
-            throw new InvalidValueException(ErrorCode.INVALID_IMAGE_POLICY);
+            throw new ImageInvalidValueException(ErrorCode.S3_IMAGE_INVALID_POLICY);
         }
         return contentType;
     }
@@ -115,12 +115,12 @@ public class ImageUploader {
      */
     private String validateExtension(final String originalFileName) {
         if (originalFileName == null || !originalFileName.contains(".")) {
-            throw new InvalidValueException(ErrorCode.INVALID_IMAGE_POLICY);
+            throw new ImageInvalidValueException(ErrorCode.S3_IMAGE_INVALID_POLICY);
         }
 
         String extension = originalFileName.substring(originalFileName.lastIndexOf('.') + 1).toLowerCase();
         if (!ImageType.isAllowedExtension(extension)) {
-            throw new InvalidValueException(ErrorCode.INVALID_IMAGE_POLICY);
+            throw new ImageInvalidValueException(ErrorCode.S3_IMAGE_INVALID_POLICY);
         }
         return extension;
     }

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
@@ -14,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
@@ -65,6 +66,49 @@ public class ImageUploader {
             log.error("이미지 삭제 중 오류가 발생했습니다. key={}", key, e);
             throw new S3Exception(ErrorCode.S3_IMAGE_DELETE_ERROR);
         }
+    }
+
+    /**
+     * 이미지를 영구 삭제하지 않고 trash 하위 경로로 이동한다(soft delete).
+     * S3는 원자적인 이동 연산이 없어서 복사 후 원본 삭제로 구현한다.
+     * 예: gachigacha/store/xxx.png -> gachigacha/trash/store/xxx.png
+     */
+    public void moveToTrash(final String imageUrl) {
+        String key = extractKeyFromUrl(imageUrl);
+        String trashKey = buildTrashKey(key);
+
+        CopyObjectRequest copyRequest = CopyObjectRequest.builder()
+                .sourceBucket(bucket)
+                .sourceKey(key)
+                .destinationBucket(bucket)
+                .destinationKey(trashKey)
+                .build();
+
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        try {
+            s3Client.copyObject(copyRequest);
+            s3Client.deleteObject(deleteRequest);
+        } catch (final SdkException e) {
+            log.error("이미지를 휴지통으로 이동하는 중 오류가 발생했습니다. key={}, trashKey={}", key, trashKey, e);
+            throw new S3Exception(ErrorCode.S3_IMAGE_MOVE_ERROR);
+        }
+    }
+
+    /**
+     * 키의 최상위 폴더(root)는 유지하고, 그 다음 위치에 trash를 끼워 넣는다.
+     * 예: gachigacha/store/xxx.png -> gachigacha/trash/store/xxx.png
+     *     gachigacha/gacha/xxx.png -> gachigacha/trash/gacha/xxx.png
+     */
+    private String buildTrashKey(final String key) {
+        int rootFolderEndIndex = key.indexOf('/');
+        String rootFolder = key.substring(0, rootFolderEndIndex);
+        String rest = key.substring(rootFolderEndIndex + 1);
+
+        return "%s/trash/%s".formatted(rootFolder, rest);
     }
 
     /**

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
@@ -1,9 +1,9 @@
-package com.gachi.gacha.server.store.infra.config;
+package com.gachi.gacha.server.common.infra.config;
 
 import com.gachi.gacha.server.common.exception.ErrorCode;
 import com.gachi.gacha.server.common.exception.InvalidValueException;
-import com.gachi.gacha.server.store.domain.ImageType;
-import com.gachi.gacha.server.store.infra.exception.S3Exception;
+import com.gachi.gacha.server.common.domain.ImageType;
+import com.gachi.gacha.server.common.infra.exception.S3Exception;
 import java.io.IOException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
@@ -1,6 +1,6 @@
 package com.gachi.gacha.server.common.infra.config;
 
-import com.gachi.gacha.server.common.domain.ImageType;
+import com.gachi.gacha.server.common.domain.ImageFormat;
 import com.gachi.gacha.server.common.exception.ErrorCode;
 import com.gachi.gacha.server.common.infra.exception.ImageInvalidValueException;
 import com.gachi.gacha.server.common.infra.exception.S3Exception;
@@ -103,7 +103,7 @@ public class ImageUploader {
      * 검증 없이 저장하면 text/html 등으로 위장한 파일이 스토어드 XSS 벡터가 될 수 있다.
      */
     private String validateContentType(final String contentType) {
-        if (!ImageType.isAllowedContentType(contentType)) {
+        if (!ImageFormat.isAllowedContentType(contentType)) {
             throw new ImageInvalidValueException(ErrorCode.S3_IMAGE_INVALID_POLICY);
         }
         return contentType;
@@ -119,7 +119,7 @@ public class ImageUploader {
         }
 
         String extension = originalFileName.substring(originalFileName.lastIndexOf('.') + 1).toLowerCase();
-        if (!ImageType.isAllowedExtension(extension)) {
+        if (!ImageFormat.isAllowedExtension(extension)) {
             throw new ImageInvalidValueException(ErrorCode.S3_IMAGE_INVALID_POLICY);
         }
         return extension;

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
@@ -73,7 +73,7 @@ public class ImageUploader {
      */
     private String validateContentType(final String contentType) {
         if (!ImageType.isAllowedContentType(contentType)) {
-            throw new InvalidValueException(ErrorCode.INVALID_STORE_IMAGE_POLICY);
+            throw new InvalidValueException(ErrorCode.INVALID_IMAGE_POLICY);
         }
         return contentType;
     }
@@ -84,12 +84,12 @@ public class ImageUploader {
      */
     private String validateExtension(final String originalFileName) {
         if (originalFileName == null || !originalFileName.contains(".")) {
-            throw new InvalidValueException(ErrorCode.INVALID_STORE_IMAGE_POLICY);
+            throw new InvalidValueException(ErrorCode.INVALID_IMAGE_POLICY);
         }
 
         String extension = originalFileName.substring(originalFileName.lastIndexOf('.') + 1).toLowerCase();
         if (!ImageType.isAllowedExtension(extension)) {
-            throw new InvalidValueException(ErrorCode.INVALID_STORE_IMAGE_POLICY);
+            throw new InvalidValueException(ErrorCode.INVALID_IMAGE_POLICY);
         }
         return extension;
     }

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/config/ImageUploader.java
@@ -75,7 +75,7 @@ public class ImageUploader {
      */
     public void moveToTrash(final String imageUrl) {
         String key = extractKeyFromUrl(imageUrl);
-        String trashKey = buildTrashKey(key);
+        String trashKey = generateTrashKey(key);
 
         CopyObjectRequest copyRequest = CopyObjectRequest.builder()
                 .sourceBucket(bucket)
@@ -96,19 +96,6 @@ public class ImageUploader {
             log.error("이미지를 휴지통으로 이동하는 중 오류가 발생했습니다. key={}, trashKey={}", key, trashKey, e);
             throw new S3Exception(ErrorCode.S3_IMAGE_MOVE_ERROR);
         }
-    }
-
-    /**
-     * 키의 최상위 폴더(root)는 유지하고, 그 다음 위치에 trash를 끼워 넣는다.
-     * 예: gachigacha/store/xxx.png -> gachigacha/trash/store/xxx.png
-     *     gachigacha/gacha/xxx.png -> gachigacha/trash/gacha/xxx.png
-     */
-    private String buildTrashKey(final String key) {
-        int rootFolderEndIndex = key.indexOf('/');
-        String rootFolder = key.substring(0, rootFolderEndIndex);
-        String rest = key.substring(rootFolderEndIndex + 1);
-
-        return "%s/trash/%s".formatted(rootFolder, rest);
     }
 
     /**
@@ -144,6 +131,19 @@ public class ImageUploader {
      */
     private String generateUniqueKey(final String path, final String extension) {
         return "%s/%s.%s".formatted(path, UUID.randomUUID(), extension);
+    }
+
+    /**
+     * 키의 최상위 폴더(root)는 유지하고, 그 다음 위치에 trash를 끼워 넣는다.
+     * 예: gachigacha/store/xxx.png -> gachigacha/trash/store/xxx.png
+     *     gachigacha/gacha/xxx.png -> gachigacha/trash/gacha/xxx.png
+     */
+    private String generateTrashKey(final String key) {
+        int rootFolderEndIndex = key.indexOf('/');
+        String rootFolder = key.substring(0, rootFolderEndIndex);
+        String pathAfterRootFolder = key.substring(rootFolderEndIndex + 1);
+
+        return "%s/trash/%s".formatted(rootFolder, pathAfterRootFolder);
     }
 
     /**

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/exception/ImageInvalidValueException.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/exception/ImageInvalidValueException.java
@@ -1,0 +1,10 @@
+package com.gachi.gacha.server.common.infra.exception;
+
+import com.gachi.gacha.server.common.exception.ErrorCode;
+import com.gachi.gacha.server.common.exception.InvalidValueException;
+
+public class ImageInvalidValueException extends InvalidValueException {
+    public ImageInvalidValueException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/common/infra/exception/S3Exception.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/infra/exception/S3Exception.java
@@ -1,4 +1,4 @@
-package com.gachi.gacha.server.store.infra.exception;
+package com.gachi.gacha.server.common.infra.exception;
 
 import com.gachi.gacha.server.common.exception.ErrorCode;
 import com.gachi.gacha.server.common.exception.ExternalApiException;

--- a/backend/src/main/java/com/gachi/gacha/server/common/util/S3TransactionManager.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/util/S3TransactionManager.java
@@ -2,7 +2,6 @@ package com.gachi.gacha.server.common.util;
 
 import com.gachi.gacha.server.common.infra.config.ImageType;
 import com.gachi.gacha.server.common.infra.config.ImageUploader;
-import com.gachi.gacha.server.common.infra.exception.S3Exception;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -77,8 +76,8 @@ public class S3TransactionManager {
     private void moveImageToTrash(final ImageType imageType, final Long domainId, final String imageUrl) {
         try {
             imageUploader.moveToTrash(imageUrl);
-        } catch (final S3Exception e) {
-            log.warn("{} 이미지를 휴지통으로 이동하는 데 실패했습니다. domainId={}, imageUrl={}",
+        } catch (final RuntimeException e) {
+            log.error("{} 이미지를 휴지통으로 이동하는 데 실패했습니다. domainId={}, imageUrl={}",
                     imageType.getLabel(), domainId, imageUrl, e);
         }
     }
@@ -86,8 +85,8 @@ public class S3TransactionManager {
     private void deleteImage(final ImageType imageType, final Long domainId, final String imageUrl) {
         try {
             imageUploader.delete(imageUrl);
-        } catch (final S3Exception e) {
-            log.warn("{} 이미지 삭제에 실패했습니다. domainId={}, imageUrl={}",
+        } catch (final RuntimeException e) {
+            log.error("{} 이미지 삭제에 실패했습니다. domainId={}, imageUrl={}",
                     imageType.getLabel(), domainId, imageUrl, e);
         }
     }

--- a/backend/src/main/java/com/gachi/gacha/server/common/util/S3TransactionManager.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/util/S3TransactionManager.java
@@ -1,0 +1,94 @@
+package com.gachi.gacha.server.common.util;
+
+import com.gachi.gacha.server.common.infra.config.ImageType;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
+import com.gachi.gacha.server.common.infra.exception.S3Exception;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * S3는 트랜잭션 매니저가 관리하는 리소스가 아니라서, DB 트랜잭션의 커밋/롤백 결과가 확정된 이후에만 S3 작업(휴지통 이동/삭제)이 실행되도록 미루는 역할을 한다. 커밋 전에 S3를 먼저 건드리면, 이후
+ * DB 작업이 실패해 롤백될 때 "DB는 되돌아갔는데 S3는 이미 바뀐" 깨진 참조 상태가 생길 수 있다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3TransactionManager {
+
+    private final ImageUploader imageUploader;
+
+    /**
+     * 이미지 1장을 새 파일로 교체(수정)할 때 사용. 커밋되면 옛 이미지를 휴지통으로 이동하고, 롤백되면 방금 올린 새 이미지를 삭제한다.
+     */
+    public void cleanupAfterImageReplaced(
+            final ImageType imageType,
+            final Long domainId,
+            final String oldImageUrl,
+            final String newImageUrl
+    ) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(final int status) {
+                if (status == TransactionSynchronization.STATUS_COMMITTED) {
+                    moveImageToTrash(imageType, domainId, oldImageUrl);
+                } else {
+                    deleteImage(imageType, domainId, newImageUrl);
+                }
+            }
+        });
+    }
+
+    /**
+     * 소유 엔티티(매장/가챠) 자체가 삭제될 때, 딸린 이미지들을 휴지통으로 이동. 복구 가능성이 남아있어야 하는 경우(예: 가챠 삭제)에 사용.
+     */
+    public void trashImagesAfterRemoved(
+            final ImageType imageType,
+            final Long domainId,
+            final List<String> imageUrls
+    ) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                imageUrls.forEach(imageUrl -> moveImageToTrash(imageType, domainId, imageUrl));
+            }
+        });
+    }
+
+    /**
+     * 소유 엔티티(매장/가챠) 자체가 삭제될 때, 딸린 이미지들을 완전 삭제. 복구가 무의미한 경우(예: 매장 삭제 - DB row 자체가 없어져서 복구 불가)에 사용.
+     */
+    public void deleteImagesAfterRemoved(
+            final ImageType imageType,
+            final Long domainId,
+            final List<String> imageUrls
+    ) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                imageUrls.forEach(imageUrl -> deleteImage(imageType, domainId, imageUrl));
+            }
+        });
+    }
+
+    private void moveImageToTrash(final ImageType imageType, final Long domainId, final String imageUrl) {
+        try {
+            imageUploader.moveToTrash(imageUrl);
+        } catch (final S3Exception e) {
+            log.warn("{} 이미지를 휴지통으로 이동하는 데 실패했습니다. domainId={}, imageUrl={}",
+                    imageType.getLabel(), domainId, imageUrl, e);
+        }
+    }
+
+    private void deleteImage(final ImageType imageType, final Long domainId, final String imageUrl) {
+        try {
+            imageUploader.delete(imageUrl);
+        } catch (final S3Exception e) {
+            log.warn("{} 이미지 삭제에 실패했습니다. domainId={}, imageUrl={}",
+                    imageType.getLabel(), domainId, imageUrl, e);
+        }
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/common/util/S3TransactionManager.java
+++ b/backend/src/main/java/com/gachi/gacha/server/common/util/S3TransactionManager.java
@@ -73,6 +73,25 @@ public class S3TransactionManager {
         });
     }
 
+    /**
+     * 이미지를 새로 등록할 때 사용. 업로드는 먼저 일어나고 DB 저장은 트랜잭션 커밋 시점에야 확정되므로,
+     * 커밋되면 아무 작업도 하지 않고, 롤백되면(메서드 본문 실행 중 실패든, 반환 이후 flush/commit 단계 실패든) 업로드된 이미지를 전부 삭제한다.
+     */
+    public void deleteImagesOnRollback(
+            final ImageType imageType,
+            final Long domainId,
+            final List<String> imageUrls
+    ) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(final int status) {
+                if (status == TransactionSynchronization.STATUS_ROLLED_BACK) {
+                    imageUrls.forEach(imageUrl -> deleteImage(imageType, domainId, imageUrl));
+                }
+            }
+        });
+    }
+
     private void moveImageToTrash(final ImageType imageType, final Long domainId, final String imageUrl) {
         try {
             imageUploader.moveToTrash(imageUrl);

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
@@ -1,32 +1,28 @@
 package com.gachi.gacha.server.gacha.application;
 
+import com.gachi.gacha.server.common.infra.config.ImageType;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
+import com.gachi.gacha.server.common.util.S3TransactionManager;
 import com.gachi.gacha.server.gacha.application.dto.GachaImageInfo;
 import com.gachi.gacha.server.gacha.domain.Gacha;
 import com.gachi.gacha.server.gacha.domain.GachaImage;
 import com.gachi.gacha.server.gacha.domain.GachaImageJpaRepository;
 import com.gachi.gacha.server.gacha.domain.GachaJpaRepository;
-import com.gachi.gacha.server.common.infra.config.ImageUploader;
-import com.gachi.gacha.server.common.infra.exception.S3Exception;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GachaImageService {
 
-    private static final String GACHA_IMAGE_FOLDER = "gacha";
-
     private final ImageUploader imageUploader;
+    private final S3TransactionManager s3TransactionManager;
     private final GachaJpaRepository gachaRepository;
     private final GachaImageJpaRepository gachaImageRepository;
 
@@ -73,7 +69,7 @@ public class GachaImageService {
         String newImageUrl = imageUploader.upload(file, imagePath());
 
         gachaImage.changeImageUrl(newImageUrl);
-        registerImageSwapCleanupAfterCompletion(gachaId, oldImageUrl, newImageUrl);
+        s3TransactionManager.cleanupAfterImageReplaced(ImageType.GACHA, gachaId, oldImageUrl, newImageUrl);
 
         return GachaImageInfo.from(gachaImage);
     }
@@ -89,35 +85,6 @@ public class GachaImageService {
     }
 
     private String imagePath() {
-        return "%s/%s".formatted(s3RootFolder, GACHA_IMAGE_FOLDER);
-    }
-
-    private void registerImageSwapCleanupAfterCompletion(final Long gachaId, final String oldImageUrl, final String newImageUrl) {
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(final int status) {
-                if (status == TransactionSynchronization.STATUS_COMMITTED) {
-                    moveToTrashQuietly(gachaId, oldImageUrl);
-                } else {
-                    deleteQuietly(gachaId, newImageUrl);
-                }
-            }
-        });
-    }
-
-    private void moveToTrashQuietly(final Long gachaId, final String imageUrl) {
-        try {
-            imageUploader.moveToTrash(imageUrl);
-        } catch (final S3Exception e) {
-            log.warn("가챠 이미지 수정 후 옛 이미지를 휴지통으로 이동하는 데 실패했습니다. gachaId={}, imageUrl={}", gachaId, imageUrl, e);
-        }
-    }
-
-    private void deleteQuietly(final Long gachaId, final String imageUrl) {
-        try {
-            imageUploader.delete(imageUrl);
-        } catch (final S3Exception e) {
-            log.warn("가챠 이미지 수정 롤백 중 새 이미지 삭제에 실패했습니다. gachaId={}, imageUrl={}", gachaId, imageUrl, e);
-        }
+        return "%s/%s".formatted(s3RootFolder, ImageType.GACHA.getFolderName());
     }
 }

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
@@ -42,23 +42,20 @@ public class GachaImageService {
         Gacha gacha = gachaRepository.getById(gachaId);
 
         List<String> uploadedImageUrls = new ArrayList<>();
-        try {
-            List<GachaImage> gachaImages = files.stream()
-                    .map(file -> {
-                        String imageUrl = imageUploader.upload(file, imagePath());
-                        uploadedImageUrls.add(imageUrl);
-                        return new GachaImage(gacha, imageUrl);
-                    })
-                    .toList();
+        s3TransactionManager.deleteImagesOnRollback(ImageType.GACHA, gachaId, uploadedImageUrls);
 
-            List<GachaImage> savedGachaImages = gachaImageRepository.saveAll(gachaImages);
-            return savedGachaImages.stream()
-                    .map(GachaImageInfo::from)
-                    .toList();
-        } catch (RuntimeException e) {
-            uploadedImageUrls.forEach(imageUploader::delete);
-            throw e;
-        }
+        List<GachaImage> gachaImages = files.stream()
+                .map(file -> {
+                    String imageUrl = imageUploader.upload(file, imagePath());
+                    uploadedImageUrls.add(imageUrl);
+                    return new GachaImage(gacha, imageUrl);
+                })
+                .toList();
+
+        List<GachaImage> savedGachaImages = gachaImageRepository.saveAll(gachaImages);
+        return savedGachaImages.stream()
+                .map(GachaImageInfo::from)
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
@@ -78,8 +78,8 @@ public class GachaImageService {
     public Long removeImage(final Long gachaId, final Long imageId) {
         GachaImage gachaImage = gachaImageRepository.getByIdAndGachaId(imageId, gachaId);
 
-        imageUploader.moveToTrash(gachaImage.getImageUrl());
         gachaImageRepository.delete(gachaImage);
+        s3TransactionManager.trashImagesAfterRemoved(ImageType.GACHA, gachaId, List.of(gachaImage.getImageUrl()));
 
         return gachaImage.getId();
     }

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
@@ -68,7 +68,7 @@ public class GachaImageService {
         String newImageUrl = imageUploader.upload(file, imagePath());
 
         gachaImage.changeImageUrl(newImageUrl);
-        imageUploader.delete(oldImageUrl);
+        imageUploader.moveToTrash(oldImageUrl);
 
         return GachaImageInfo.from(gachaImage);
     }
@@ -77,7 +77,7 @@ public class GachaImageService {
     public Long removeImage(final Long gachaId, final Long imageId) {
         GachaImage gachaImage = gachaImageRepository.getByIdAndGachaId(imageId, gachaId);
 
-        imageUploader.delete(gachaImage.getImageUrl());
+        imageUploader.moveToTrash(gachaImage.getImageUrl());
         gachaImageRepository.delete(gachaImage);
 
         return gachaImage.getId();

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
@@ -1,0 +1,89 @@
+package com.gachi.gacha.server.gacha.application;
+
+import com.gachi.gacha.server.gacha.application.dto.GachaImageInfo;
+import com.gachi.gacha.server.gacha.domain.Gacha;
+import com.gachi.gacha.server.gacha.domain.GachaImage;
+import com.gachi.gacha.server.gacha.domain.GachaImageJpaRepository;
+import com.gachi.gacha.server.gacha.domain.GachaJpaRepository;
+import com.gachi.gacha.server.store.infra.config.ImageUploader;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GachaImageService {
+
+    private static final String GACHA_IMAGE_FOLDER = "gacha";
+
+    private final ImageUploader imageUploader;
+    private final GachaJpaRepository gachaRepository;
+    private final GachaImageJpaRepository gachaImageRepository;
+
+    @Value("${cloud.aws.s3.folder}")
+    private String s3RootFolder;
+
+    public List<GachaImageInfo> findImages(final Long gachaId) {
+        Gacha gacha = gachaRepository.getById(gachaId);
+
+        return gachaImageRepository.findAllByGachaId(gacha.getId()).stream()
+                .map(GachaImageInfo::from)
+                .toList();
+    }
+
+    @Transactional
+    public List<GachaImageInfo> addImage(final Long gachaId, final List<MultipartFile> files) {
+        Gacha gacha = gachaRepository.getById(gachaId);
+
+        List<String> uploadedImageUrls = new ArrayList<>();
+        try {
+            List<GachaImage> gachaImages = files.stream()
+                    .map(file -> {
+                        String imageUrl = imageUploader.upload(file, imagePath());
+                        uploadedImageUrls.add(imageUrl);
+                        return new GachaImage(gacha, imageUrl);
+                    })
+                    .toList();
+
+            List<GachaImage> savedGachaImages = gachaImageRepository.saveAll(gachaImages);
+            return savedGachaImages.stream()
+                    .map(GachaImageInfo::from)
+                    .toList();
+        } catch (RuntimeException e) {
+            uploadedImageUrls.forEach(imageUploader::delete);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public GachaImageInfo modifyImage(final Long gachaId, final Long imageId, final MultipartFile file) {
+        GachaImage gachaImage = gachaImageRepository.getByIdAndGachaId(imageId, gachaId);
+
+        String oldImageUrl = gachaImage.getImageUrl();
+        String newImageUrl = imageUploader.upload(file, imagePath());
+
+        gachaImage.changeImageUrl(newImageUrl);
+        imageUploader.delete(oldImageUrl);
+
+        return GachaImageInfo.from(gachaImage);
+    }
+
+    @Transactional
+    public Long removeImage(final Long gachaId, final Long imageId) {
+        GachaImage gachaImage = gachaImageRepository.getByIdAndGachaId(imageId, gachaId);
+
+        imageUploader.delete(gachaImage.getImageUrl());
+        gachaImageRepository.delete(gachaImage);
+
+        return gachaImage.getId();
+    }
+
+    private String imagePath() {
+        return "%s/%s".formatted(s3RootFolder, GACHA_IMAGE_FOLDER);
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
@@ -6,14 +6,19 @@ import com.gachi.gacha.server.gacha.domain.GachaImage;
 import com.gachi.gacha.server.gacha.domain.GachaImageJpaRepository;
 import com.gachi.gacha.server.gacha.domain.GachaJpaRepository;
 import com.gachi.gacha.server.common.infra.config.ImageUploader;
+import com.gachi.gacha.server.common.infra.exception.S3Exception;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -68,7 +73,7 @@ public class GachaImageService {
         String newImageUrl = imageUploader.upload(file, imagePath());
 
         gachaImage.changeImageUrl(newImageUrl);
-        imageUploader.moveToTrash(oldImageUrl);
+        registerImageSwapCleanupAfterCompletion(gachaId, oldImageUrl, newImageUrl);
 
         return GachaImageInfo.from(gachaImage);
     }
@@ -85,5 +90,34 @@ public class GachaImageService {
 
     private String imagePath() {
         return "%s/%s".formatted(s3RootFolder, GACHA_IMAGE_FOLDER);
+    }
+
+    private void registerImageSwapCleanupAfterCompletion(final Long gachaId, final String oldImageUrl, final String newImageUrl) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(final int status) {
+                if (status == TransactionSynchronization.STATUS_COMMITTED) {
+                    moveToTrashQuietly(gachaId, oldImageUrl);
+                } else {
+                    deleteQuietly(gachaId, newImageUrl);
+                }
+            }
+        });
+    }
+
+    private void moveToTrashQuietly(final Long gachaId, final String imageUrl) {
+        try {
+            imageUploader.moveToTrash(imageUrl);
+        } catch (final S3Exception e) {
+            log.warn("가챠 이미지 수정 후 옛 이미지를 휴지통으로 이동하는 데 실패했습니다. gachaId={}, imageUrl={}", gachaId, imageUrl, e);
+        }
+    }
+
+    private void deleteQuietly(final Long gachaId, final String imageUrl) {
+        try {
+            imageUploader.delete(imageUrl);
+        } catch (final S3Exception e) {
+            log.warn("가챠 이미지 수정 롤백 중 새 이미지 삭제에 실패했습니다. gachaId={}, imageUrl={}", gachaId, imageUrl, e);
+        }
     }
 }

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaImageService.java
@@ -5,7 +5,7 @@ import com.gachi.gacha.server.gacha.domain.Gacha;
 import com.gachi.gacha.server.gacha.domain.GachaImage;
 import com.gachi.gacha.server.gacha.domain.GachaImageJpaRepository;
 import com.gachi.gacha.server.gacha.domain.GachaJpaRepository;
-import com.gachi.gacha.server.store.infra.config.ImageUploader;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
@@ -59,7 +59,7 @@ public class GachaService {
         List<GachaImage> gachaImages = gachaImageRepository.findAllByGachaId(gachaId);
         for (GachaImage gachaImage : gachaImages) {
             try {
-                imageUploader.delete(gachaImage.getImageUrl());
+                imageUploader.moveToTrash(gachaImage.getImageUrl());
             } catch (RuntimeException e) {
                 log.warn("가챠 삭제 중 S3 이미지 삭제에 실패했습니다. gachaId={}, imageUrl={}", gachaId, gachaImage.getImageUrl(), e);
             }

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
@@ -6,20 +6,28 @@ import com.gachi.gacha.server.gacha.application.dto.GachaInfo;
 import com.gachi.gacha.server.gacha.application.dto.GachaResult;
 import com.gachi.gacha.server.gacha.application.dto.GachaUpdateCommand;
 import com.gachi.gacha.server.gacha.domain.Gacha;
+import com.gachi.gacha.server.gacha.domain.GachaImage;
+import com.gachi.gacha.server.gacha.domain.GachaImageJpaRepository;
 import com.gachi.gacha.server.gacha.domain.GachaJpaRepository;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class GachaService {
 
     private final GachaJpaRepository gachaRepository;
+    private final GachaImageJpaRepository gachaImageRepository;
+    private final ImageUploader imageUploader;
 
     @Transactional
     public GachaInfo addGacha(final GachaCreateCommand command) {
@@ -39,8 +47,23 @@ public class GachaService {
     @Transactional
     public GachaDeleteResult remove(final Long gachaId) {
         Gacha gacha = gachaRepository.getById(gachaId);
+
+        deleteGachaImagesFromS3(gachaId);
+        gachaImageRepository.deleteAllByGachaId(gachaId);
         gachaRepository.deleteById(gachaId);
+
         return GachaDeleteResult.from(gacha);
+    }
+
+    private void deleteGachaImagesFromS3(final Long gachaId) {
+        List<GachaImage> gachaImages = gachaImageRepository.findAllByGachaId(gachaId);
+        for (GachaImage gachaImage : gachaImages) {
+            try {
+                imageUploader.delete(gachaImage.getImageUrl());
+            } catch (RuntimeException e) {
+                log.warn("가챠 삭제 중 S3 이미지 삭제에 실패했습니다. gachaId={}, imageUrl={}", gachaId, gachaImage.getImageUrl(), e);
+            }
+        }
     }
 
     public Page<GachaInfo> findAllGacha(@Nullable final String keyword, final Pageable pageable) {

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
@@ -1,5 +1,6 @@
 package com.gachi.gacha.server.gacha.application;
 
+import com.gachi.gacha.server.common.infra.exception.S3Exception;
 import com.gachi.gacha.server.gacha.application.dto.GachaCreateCommand;
 import com.gachi.gacha.server.gacha.application.dto.GachaDeleteResult;
 import com.gachi.gacha.server.gacha.application.dto.GachaInfo;
@@ -18,6 +19,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -47,10 +50,12 @@ public class GachaService {
     @Transactional
     public GachaDeleteResult remove(final Long gachaId) {
         Gacha gacha = gachaRepository.getById(gachaId);
+        List<GachaImage> gachaImages = gachaImageRepository.findAllByGachaId(gachaId);
 
-        deleteGachaImagesFromS3(gachaId);
         gachaImageRepository.deleteAllByGachaId(gachaId);
         gachaRepository.deleteById(gachaId);
+
+        registerGachaImageCleanupAfterCommit(gachaId, gachaImages);
 
         return GachaDeleteResult.from(gacha);
     }
@@ -72,17 +77,21 @@ public class GachaService {
         return gachaRepository.getById(gachaId);
     }
 
-    private void deleteGachaImagesFromS3(final Long gachaId) {
-        List<GachaImage> gachaImages = gachaImageRepository.findAllByGachaId(gachaId);
-        for (GachaImage gachaImage : gachaImages) {
-            moveFileToTrash(gachaId, gachaImage);
-        }
+    private void registerGachaImageCleanupAfterCommit(final Long gachaId, final List<GachaImage> gachaImages) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                for (GachaImage gachaImage : gachaImages) {
+                    moveFileToTrash(gachaId, gachaImage);
+                }
+            }
+        });
     }
 
-    private void moveFileToTrash(Long gachaId, GachaImage gachaImage) {
+    private void moveFileToTrash(final Long gachaId, final GachaImage gachaImage) {
         try {
             imageUploader.moveToTrash(gachaImage.getImageUrl());
-        } catch (RuntimeException e) {
+        } catch (S3Exception e) {
             log.warn("가챠 삭제 중 S3 이미지 삭제에 실패했습니다. gachaId={}, imageUrl={}", gachaId, gachaImage.getImageUrl(), e);
         }
     }

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
@@ -55,17 +55,6 @@ public class GachaService {
         return GachaDeleteResult.from(gacha);
     }
 
-    private void deleteGachaImagesFromS3(final Long gachaId) {
-        List<GachaImage> gachaImages = gachaImageRepository.findAllByGachaId(gachaId);
-        for (GachaImage gachaImage : gachaImages) {
-            try {
-                imageUploader.moveToTrash(gachaImage.getImageUrl());
-            } catch (RuntimeException e) {
-                log.warn("가챠 삭제 중 S3 이미지 삭제에 실패했습니다. gachaId={}, imageUrl={}", gachaId, gachaImage.getImageUrl(), e);
-            }
-        }
-    }
-
     public Page<GachaInfo> findAllGacha(@Nullable final String keyword, final Pageable pageable) {
         if (keyword == null) {
             return gachaRepository.findAll(pageable)
@@ -81,5 +70,20 @@ public class GachaService {
 
     public Gacha findByGachaId(final Long gachaId) {
         return gachaRepository.getById(gachaId);
+    }
+
+    private void deleteGachaImagesFromS3(final Long gachaId) {
+        List<GachaImage> gachaImages = gachaImageRepository.findAllByGachaId(gachaId);
+        for (GachaImage gachaImage : gachaImages) {
+            moveFileToTrash(gachaId, gachaImage);
+        }
+    }
+
+    private void moveFileToTrash(Long gachaId, GachaImage gachaImage) {
+        try {
+            imageUploader.moveToTrash(gachaImage.getImageUrl());
+        } catch (RuntimeException e) {
+            log.warn("가챠 삭제 중 S3 이미지 삭제에 실패했습니다. gachaId={}, imageUrl={}", gachaId, gachaImage.getImageUrl(), e);
+        }
     }
 }

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/GachaService.java
@@ -1,6 +1,7 @@
 package com.gachi.gacha.server.gacha.application;
 
-import com.gachi.gacha.server.common.infra.exception.S3Exception;
+import com.gachi.gacha.server.common.infra.config.ImageType;
+import com.gachi.gacha.server.common.util.S3TransactionManager;
 import com.gachi.gacha.server.gacha.application.dto.GachaCreateCommand;
 import com.gachi.gacha.server.gacha.application.dto.GachaDeleteResult;
 import com.gachi.gacha.server.gacha.application.dto.GachaInfo;
@@ -10,19 +11,14 @@ import com.gachi.gacha.server.gacha.domain.Gacha;
 import com.gachi.gacha.server.gacha.domain.GachaImage;
 import com.gachi.gacha.server.gacha.domain.GachaImageJpaRepository;
 import com.gachi.gacha.server.gacha.domain.GachaJpaRepository;
-import com.gachi.gacha.server.common.infra.config.ImageUploader;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -30,7 +26,7 @@ public class GachaService {
 
     private final GachaJpaRepository gachaRepository;
     private final GachaImageJpaRepository gachaImageRepository;
-    private final ImageUploader imageUploader;
+    private final S3TransactionManager s3TransactionManager;
 
     @Transactional
     public GachaInfo addGacha(final GachaCreateCommand command) {
@@ -55,7 +51,8 @@ public class GachaService {
         gachaImageRepository.deleteAllByGachaId(gachaId);
         gachaRepository.deleteById(gachaId);
 
-        registerGachaImageCleanupAfterCommit(gachaId, gachaImages);
+        List<String> imageUrls = gachaImages.stream().map(GachaImage::getImageUrl).toList();
+        s3TransactionManager.trashImagesAfterRemoved(ImageType.GACHA, gachaId, imageUrls);
 
         return GachaDeleteResult.from(gacha);
     }
@@ -75,24 +72,5 @@ public class GachaService {
 
     public Gacha findByGachaId(final Long gachaId) {
         return gachaRepository.getById(gachaId);
-    }
-
-    private void registerGachaImageCleanupAfterCommit(final Long gachaId, final List<GachaImage> gachaImages) {
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                for (GachaImage gachaImage : gachaImages) {
-                    moveFileToTrash(gachaId, gachaImage);
-                }
-            }
-        });
-    }
-
-    private void moveFileToTrash(final Long gachaId, final GachaImage gachaImage) {
-        try {
-            imageUploader.moveToTrash(gachaImage.getImageUrl());
-        } catch (S3Exception e) {
-            log.warn("가챠 삭제 중 S3 이미지 삭제에 실패했습니다. gachaId={}, imageUrl={}", gachaId, gachaImage.getImageUrl(), e);
-        }
     }
 }

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/application/dto/GachaImageInfo.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/application/dto/GachaImageInfo.java
@@ -1,0 +1,17 @@
+package com.gachi.gacha.server.gacha.application.dto;
+
+import com.gachi.gacha.server.gacha.domain.GachaImage;
+import lombok.Builder;
+
+@Builder
+public record GachaImageInfo(
+        Long gachaImageId,
+        String imageUrl
+) {
+    public static GachaImageInfo from(final GachaImage gachaImage) {
+        return GachaImageInfo.builder()
+                .gachaImageId(gachaImage.getId())
+                .imageUrl(gachaImage.getImageUrl())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/domain/GachaImage.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/domain/GachaImage.java
@@ -1,0 +1,48 @@
+package com.gachi.gacha.server.gacha.domain;
+
+import com.gachi.gacha.server.common.exception.ErrorCode;
+import com.gachi.gacha.server.gacha.domain.exception.GachaImageInvalidValueException;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GachaImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "gacha_id", nullable = false)
+    private Gacha gacha;
+
+    @NotNull
+    private String imageUrl;
+
+    public GachaImage(final Gacha gacha, final String imageUrl) {
+        this.gacha = gacha;
+        this.imageUrl = imageUrl;
+    }
+
+    public void changeImageUrl(final String newImageUrl) {
+        if (newImageUrl == null) {
+            throw new GachaImageInvalidValueException(ErrorCode.INVALID_GACHA_IMAGE_POLICY);
+        }
+        this.imageUrl = newImageUrl;
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/domain/GachaImageJpaRepository.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/domain/GachaImageJpaRepository.java
@@ -1,0 +1,24 @@
+package com.gachi.gacha.server.gacha.domain;
+
+import com.gachi.gacha.server.common.exception.ErrorCode;
+import com.gachi.gacha.server.gacha.domain.exception.GachaImageNotFoundException;
+import java.util.List;
+import java.util.Optional;
+import org.jspecify.annotations.NonNull;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GachaImageJpaRepository extends JpaRepository<GachaImage, Long> {
+
+    default GachaImage getByIdAndGachaId(@NonNull final Long imageId, @NonNull final Long gachaId) {
+        return findByIdAndGachaId(imageId, gachaId)
+                .orElseThrow(() -> new GachaImageNotFoundException(ErrorCode.GACHA_IMAGE_NOT_FOUND));
+    }
+
+    List<GachaImage> findAllByGachaId(final Long gachaId);
+
+    Optional<GachaImage> findByIdAndGachaId(final Long imageId, final Long gachaId);
+
+    void deleteAllByGachaId(final Long gachaId);
+}

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/domain/exception/GachaImageInvalidValueException.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/domain/exception/GachaImageInvalidValueException.java
@@ -1,0 +1,10 @@
+package com.gachi.gacha.server.gacha.domain.exception;
+
+import com.gachi.gacha.server.common.exception.ErrorCode;
+import com.gachi.gacha.server.common.exception.InvalidValueException;
+
+public class GachaImageInvalidValueException extends InvalidValueException {
+    public GachaImageInvalidValueException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/domain/exception/GachaImageNotFoundException.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/domain/exception/GachaImageNotFoundException.java
@@ -1,0 +1,11 @@
+package com.gachi.gacha.server.gacha.domain.exception;
+
+import com.gachi.gacha.server.common.exception.EntityNotFoundException;
+import com.gachi.gacha.server.common.exception.ErrorCode;
+
+public class GachaImageNotFoundException extends EntityNotFoundException {
+
+    public GachaImageNotFoundException(final ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/presentation/GachaImageController.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/presentation/GachaImageController.java
@@ -1,0 +1,74 @@
+package com.gachi.gacha.server.gacha.presentation;
+
+import com.gachi.gacha.server.common.domain.BaseCode;
+import com.gachi.gacha.server.common.domain.dto.BaseResponse;
+import com.gachi.gacha.server.gacha.application.GachaImageService;
+import com.gachi.gacha.server.gacha.application.dto.GachaImageInfo;
+import com.gachi.gacha.server.gacha.presentation.dto.GachaImageDeleteResponse;
+import com.gachi.gacha.server.gacha.presentation.dto.GachaImageListResponse;
+import com.gachi.gacha.server.gacha.presentation.dto.GachaImageResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/gachas/{gachaId}/images")
+@RequiredArgsConstructor
+public class GachaImageController {
+
+    private final GachaImageService gachaImageService;
+
+    @GetMapping
+    public BaseResponse<GachaImageListResponse> findImages(@PathVariable final Long gachaId) {
+        List<GachaImageResponse> responses = gachaImageService.findImages(gachaId).stream()
+                .map(GachaImageResponse::from)
+                .toList();
+
+        return BaseResponse.ok(GachaImageListResponse.from(responses));
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse<GachaImageListResponse>> addImage(
+            @PathVariable final Long gachaId,
+            @RequestParam("images") final List<MultipartFile> images
+    ) {
+        List<GachaImageResponse> responses = gachaImageService.addImage(gachaId, images).stream()
+                .map(GachaImageResponse::from)
+                .toList();
+
+        return ResponseEntity.status(BaseCode.CREATED.getStatus())
+                .body(BaseResponse.of(BaseCode.CREATED, GachaImageListResponse.from(responses)));
+    }
+
+    @PutMapping(path = "/{gachaImageId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BaseResponse<GachaImageResponse> modifyImage(
+            @PathVariable final Long gachaId,
+            @PathVariable final Long gachaImageId,
+            @RequestParam("image") final MultipartFile image
+    ) {
+        GachaImageInfo gachaImageInfo = gachaImageService.modifyImage(gachaId, gachaImageId, image);
+        GachaImageResponse response = GachaImageResponse.from(gachaImageInfo);
+
+        return BaseResponse.updated(response);
+    }
+
+    @DeleteMapping("/{gachaImageId}")
+    public BaseResponse<GachaImageDeleteResponse> removeImage(
+            @PathVariable final Long gachaId,
+            @PathVariable final Long gachaImageId
+    ) {
+        Long deletedId = gachaImageService.removeImage(gachaId, gachaImageId);
+
+        return BaseResponse.deleted(GachaImageDeleteResponse.from(deletedId));
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/presentation/dto/GachaImageDeleteResponse.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/presentation/dto/GachaImageDeleteResponse.java
@@ -1,0 +1,14 @@
+package com.gachi.gacha.server.gacha.presentation.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GachaImageDeleteResponse(
+        Long gachaImageId
+) {
+    public static GachaImageDeleteResponse from(final Long gachaImageId) {
+        return GachaImageDeleteResponse.builder()
+                .gachaImageId(gachaImageId)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/presentation/dto/GachaImageListResponse.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/presentation/dto/GachaImageListResponse.java
@@ -1,0 +1,15 @@
+package com.gachi.gacha.server.gacha.presentation.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record GachaImageListResponse(
+        List<GachaImageResponse> items
+) {
+    public static GachaImageListResponse from(final List<GachaImageResponse> items) {
+        return GachaImageListResponse.builder()
+                .items(items)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/gacha/presentation/dto/GachaImageResponse.java
+++ b/backend/src/main/java/com/gachi/gacha/server/gacha/presentation/dto/GachaImageResponse.java
@@ -1,0 +1,17 @@
+package com.gachi.gacha.server.gacha.presentation.dto;
+
+import com.gachi.gacha.server.gacha.application.dto.GachaImageInfo;
+import lombok.Builder;
+
+@Builder
+public record GachaImageResponse(
+        Long gachaImageId,
+        String imageUrl
+) {
+    public static GachaImageResponse from(final GachaImageInfo gachaImageInfo) {
+        return GachaImageResponse.builder()
+                .gachaImageId(gachaImageInfo.gachaImageId())
+                .imageUrl(gachaImageInfo.imageUrl())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
@@ -42,23 +42,20 @@ public class StoreImageService {
         Store store = storeRepository.getById(storeId);
 
         List<String> uploadedImageUrls = new ArrayList<>();
-        try {
-            List<StoreImage> storeImages = files.stream()
-                    .map(file -> {
-                        String imageUrl = imageUploader.upload(file, imagePath());
-                        uploadedImageUrls.add(imageUrl);
-                        return new StoreImage(store, imageUrl);
-                    })
-                    .toList();
+        s3TransactionManager.deleteImagesOnRollback(ImageType.STORE, storeId, uploadedImageUrls);
 
-            List<StoreImage> savedStoreImages = storeImageRepository.saveAll(storeImages);
-            return savedStoreImages.stream()
-                    .map(StoreImageInfo::from)
-                    .toList();
-        } catch (RuntimeException e) {
-            uploadedImageUrls.forEach(imageUploader::delete);
-            throw e;
-        }
+        List<StoreImage> storeImages = files.stream()
+                .map(file -> {
+                    String imageUrl = imageUploader.upload(file, imagePath());
+                    uploadedImageUrls.add(imageUrl);
+                    return new StoreImage(store, imageUrl);
+                })
+                .toList();
+
+        List<StoreImage> savedStoreImages = storeImageRepository.saveAll(storeImages);
+        return savedStoreImages.stream()
+                .map(StoreImageInfo::from)
+                .toList();
     }
 
     @Transactional

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
@@ -6,14 +6,19 @@ import com.gachi.gacha.server.store.domain.StoreImage;
 import com.gachi.gacha.server.store.domain.StoreImageJpaRepository;
 import com.gachi.gacha.server.store.domain.StoreJpaRepository;
 import com.gachi.gacha.server.common.infra.config.ImageUploader;
+import com.gachi.gacha.server.common.infra.exception.S3Exception;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -68,7 +73,7 @@ public class StoreImageService {
         String newImageUrl = imageUploader.upload(file, imagePath());
 
         storeImage.changeImageUrl(newImageUrl);
-        imageUploader.moveToTrash(oldImageUrl);
+        registerImageSwapCleanupAfterCompletion(storeId, oldImageUrl, newImageUrl);
 
         return StoreImageInfo.from(storeImage);
     }
@@ -85,5 +90,34 @@ public class StoreImageService {
 
     private String imagePath() {
         return "%s/%s".formatted(s3RootFolder, STORE_IMAGE_FOLDER);
+    }
+
+    private void registerImageSwapCleanupAfterCompletion(final Long storeId, final String oldImageUrl, final String newImageUrl) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCompletion(final int status) {
+                if (status == TransactionSynchronization.STATUS_COMMITTED) {
+                    moveToTrashQuietly(storeId, oldImageUrl);
+                } else {
+                    deleteQuietly(storeId, newImageUrl);
+                }
+            }
+        });
+    }
+
+    private void moveToTrashQuietly(final Long storeId, final String imageUrl) {
+        try {
+            imageUploader.moveToTrash(imageUrl);
+        } catch (final S3Exception e) {
+            log.warn("매장 이미지 수정 후 옛 이미지를 휴지통으로 이동하는 데 실패했습니다. storeId={}, imageUrl={}", storeId, imageUrl, e);
+        }
+    }
+
+    private void deleteQuietly(final Long storeId, final String imageUrl) {
+        try {
+            imageUploader.delete(imageUrl);
+        } catch (final S3Exception e) {
+            log.warn("매장 이미지 수정 롤백 중 새 이미지 삭제에 실패했습니다. storeId={}, imageUrl={}", storeId, imageUrl, e);
+        }
     }
 }

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
@@ -68,7 +68,7 @@ public class StoreImageService {
         String newImageUrl = imageUploader.upload(file, imagePath());
 
         storeImage.changeImageUrl(newImageUrl);
-        imageUploader.delete(oldImageUrl);
+        imageUploader.moveToTrash(oldImageUrl);
 
         return StoreImageInfo.from(storeImage);
     }
@@ -77,7 +77,7 @@ public class StoreImageService {
     public Long removeImage(final Long storeId, final Long imageId) {
         StoreImage storeImage = storeImageRepository.getByIdAndStoreId(imageId, storeId);
 
-        imageUploader.delete(storeImage.getImageUrl());
+        imageUploader.moveToTrash(storeImage.getImageUrl());
         storeImageRepository.delete(storeImage);
 
         return storeImage.getId();

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
@@ -78,8 +78,8 @@ public class StoreImageService {
     public Long removeImage(final Long storeId, final Long imageId) {
         StoreImage storeImage = storeImageRepository.getByIdAndStoreId(imageId, storeId);
 
-        imageUploader.moveToTrash(storeImage.getImageUrl());
         storeImageRepository.delete(storeImage);
+        s3TransactionManager.trashImagesAfterRemoved(ImageType.STORE, storeId, List.of(storeImage.getImageUrl()));
 
         return storeImage.getId();
     }

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
@@ -5,7 +5,7 @@ import com.gachi.gacha.server.store.domain.Store;
 import com.gachi.gacha.server.store.domain.StoreImage;
 import com.gachi.gacha.server.store.domain.StoreImageJpaRepository;
 import com.gachi.gacha.server.store.domain.StoreJpaRepository;
-import com.gachi.gacha.server.store.infra.config.ImageUploader;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreImageService.java
@@ -1,32 +1,28 @@
 package com.gachi.gacha.server.store.application;
 
+import com.gachi.gacha.server.common.infra.config.ImageType;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
+import com.gachi.gacha.server.common.util.S3TransactionManager;
 import com.gachi.gacha.server.store.application.dto.StoreImageInfo;
 import com.gachi.gacha.server.store.domain.Store;
 import com.gachi.gacha.server.store.domain.StoreImage;
 import com.gachi.gacha.server.store.domain.StoreImageJpaRepository;
 import com.gachi.gacha.server.store.domain.StoreJpaRepository;
-import com.gachi.gacha.server.common.infra.config.ImageUploader;
-import com.gachi.gacha.server.common.infra.exception.S3Exception;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StoreImageService {
 
-    private static final String STORE_IMAGE_FOLDER = "store";
-
     private final ImageUploader imageUploader;
+    private final S3TransactionManager s3TransactionManager;
     private final StoreJpaRepository storeRepository;
     private final StoreImageJpaRepository storeImageRepository;
 
@@ -73,7 +69,7 @@ public class StoreImageService {
         String newImageUrl = imageUploader.upload(file, imagePath());
 
         storeImage.changeImageUrl(newImageUrl);
-        registerImageSwapCleanupAfterCompletion(storeId, oldImageUrl, newImageUrl);
+        s3TransactionManager.cleanupAfterImageReplaced(ImageType.STORE, storeId, oldImageUrl, newImageUrl);
 
         return StoreImageInfo.from(storeImage);
     }
@@ -89,35 +85,6 @@ public class StoreImageService {
     }
 
     private String imagePath() {
-        return "%s/%s".formatted(s3RootFolder, STORE_IMAGE_FOLDER);
-    }
-
-    private void registerImageSwapCleanupAfterCompletion(final Long storeId, final String oldImageUrl, final String newImageUrl) {
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCompletion(final int status) {
-                if (status == TransactionSynchronization.STATUS_COMMITTED) {
-                    moveToTrashQuietly(storeId, oldImageUrl);
-                } else {
-                    deleteQuietly(storeId, newImageUrl);
-                }
-            }
-        });
-    }
-
-    private void moveToTrashQuietly(final Long storeId, final String imageUrl) {
-        try {
-            imageUploader.moveToTrash(imageUrl);
-        } catch (final S3Exception e) {
-            log.warn("매장 이미지 수정 후 옛 이미지를 휴지통으로 이동하는 데 실패했습니다. storeId={}, imageUrl={}", storeId, imageUrl, e);
-        }
-    }
-
-    private void deleteQuietly(final Long storeId, final String imageUrl) {
-        try {
-            imageUploader.delete(imageUrl);
-        } catch (final S3Exception e) {
-            log.warn("매장 이미지 수정 롤백 중 새 이미지 삭제에 실패했습니다. storeId={}, imageUrl={}", storeId, imageUrl, e);
-        }
+        return "%s/%s".formatted(s3RootFolder, ImageType.STORE.getFolderName());
     }
 }

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
@@ -19,11 +19,13 @@ import com.gachi.gacha.server.store.domain.StoreImageJpaRepository;
 import com.gachi.gacha.server.store.domain.StoreJpaRepository;
 import com.gachi.gacha.server.store.domain.exception.InvalidNearbyRequestException;
 import com.gachi.gacha.server.store.domain.exception.StoreNotFoundException;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import net.sf.geographiclib.Geodesic;
 import net.sf.geographiclib.GeodesicData;
 import org.springframework.data.domain.Page;
@@ -31,6 +33,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -43,6 +46,7 @@ public class StoreService {
     private final StoreJpaRepository storeJpaRepository;
     private final StoreDetailJpaRepository storeDetailJpaRepository;
     private final StoreImageJpaRepository storeImageJpaRepository;
+    private final ImageUploader imageUploader;
 
     public StoreNearbyResult findNearbyStores(
             final Double latitude,
@@ -117,6 +121,7 @@ public class StoreService {
         Store store = storeJpaRepository.getById(storeId);
         StoreDetail storeDetail = storeDetailJpaRepository.getByStoreId(storeId);
 
+        deleteStoreImagesFromS3(storeId);
         storeImageJpaRepository.deleteAllByStoreId(storeId);
         storeDetailJpaRepository.delete(storeDetail);
         storeJpaRepository.delete(store);
@@ -210,7 +215,6 @@ public class StoreService {
             final Double targetLatitude,
             final Double targetLongitude
     ) {
-
         GeodesicData result = Geodesic.WGS84.Inverse(
                 originLatitude,
                 originLongitude,
@@ -219,6 +223,17 @@ public class StoreService {
         );
 
         return result.s12;
+    }
+
+    private void deleteStoreImagesFromS3(final Long storeId) {
+        List<StoreImage> storeImages = storeImageJpaRepository.findAllByStoreId(storeId);
+        for (StoreImage storeImage : storeImages) {
+            try {
+                imageUploader.delete(storeImage.getImageUrl());
+            } catch (RuntimeException e) {
+                log.warn("매장 삭제 중 S3 이미지 삭제에 실패했습니다. storeId={}, imageUrl={}", storeId, storeImage.getImageUrl(), e);
+            }
+        }
     }
 
     private record StoreDistance(

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
@@ -2,7 +2,8 @@ package com.gachi.gacha.server.store.application;
 
 import com.gachi.gacha.server.common.exception.ErrorCode;
 import com.gachi.gacha.server.common.exception.InvalidPageRequestException;
-import com.gachi.gacha.server.common.infra.exception.S3Exception;
+import com.gachi.gacha.server.common.infra.config.ImageType;
+import com.gachi.gacha.server.common.util.S3TransactionManager;
 import com.gachi.gacha.server.store.application.dto.StoreCreateCommand;
 import com.gachi.gacha.server.store.application.dto.StoreCreateResult;
 import com.gachi.gacha.server.store.application.dto.StoreDeleteResult;
@@ -20,23 +21,18 @@ import com.gachi.gacha.server.store.domain.StoreImageJpaRepository;
 import com.gachi.gacha.server.store.domain.StoreJpaRepository;
 import com.gachi.gacha.server.store.domain.exception.InvalidNearbyRequestException;
 import com.gachi.gacha.server.store.domain.exception.StoreNotFoundException;
-import com.gachi.gacha.server.common.infra.config.ImageUploader;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import net.sf.geographiclib.Geodesic;
 import net.sf.geographiclib.GeodesicData;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -49,7 +45,7 @@ public class StoreService {
     private final StoreJpaRepository storeJpaRepository;
     private final StoreDetailJpaRepository storeDetailJpaRepository;
     private final StoreImageJpaRepository storeImageJpaRepository;
-    private final ImageUploader imageUploader;
+    private final S3TransactionManager s3TransactionManager;
 
     public StoreNearbyResult findNearbyStores(
             final Double latitude,
@@ -129,7 +125,8 @@ public class StoreService {
         storeDetailJpaRepository.delete(storeDetail);
         storeJpaRepository.delete(store);
 
-        registerStoreImageCleanupAfterCommit(storeId, storeImages);
+        List<String> imageUrls = storeImages.stream().map(StoreImage::getImageUrl).toList();
+        s3TransactionManager.deleteImagesAfterRemoved(ImageType.STORE, storeId, imageUrls);
 
         return StoreDeleteResult.from(store);
     }
@@ -228,25 +225,6 @@ public class StoreService {
         );
 
         return result.s12;
-    }
-
-    private void registerStoreImageCleanupAfterCommit(final Long storeId, final List<StoreImage> storeImages) {
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                for (StoreImage storeImage : storeImages) {
-                    deleteFile(storeId, storeImage);
-                }
-            }
-        });
-    }
-
-    private void deleteFile(final Long storeId, final StoreImage storeImage) {
-        try {
-            imageUploader.delete(storeImage.getImageUrl());
-        } catch (final S3Exception e) {
-            log.warn("매장 삭제 중 S3 이미지 삭제에 실패했습니다. storeId={}, imageUrl={}", storeId, storeImage.getImageUrl(), e);
-        }
     }
 
     private record StoreDistance(

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
@@ -3,6 +3,7 @@ package com.gachi.gacha.server.store.application;
 import com.gachi.gacha.server.common.exception.ErrorCode;
 import com.gachi.gacha.server.common.exception.InvalidPageRequestException;
 import com.gachi.gacha.server.common.infra.config.ImageType;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
 import com.gachi.gacha.server.common.util.S3TransactionManager;
 import com.gachi.gacha.server.store.application.dto.StoreCreateCommand;
 import com.gachi.gacha.server.store.application.dto.StoreCreateResult;
@@ -21,6 +22,7 @@ import com.gachi.gacha.server.store.domain.StoreImageJpaRepository;
 import com.gachi.gacha.server.store.domain.StoreJpaRepository;
 import com.gachi.gacha.server.store.domain.exception.InvalidNearbyRequestException;
 import com.gachi.gacha.server.store.domain.exception.StoreNotFoundException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -28,10 +30,12 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import net.sf.geographiclib.Geodesic;
 import net.sf.geographiclib.GeodesicData;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional(readOnly = true)
@@ -46,6 +50,10 @@ public class StoreService {
     private final StoreDetailJpaRepository storeDetailJpaRepository;
     private final StoreImageJpaRepository storeImageJpaRepository;
     private final S3TransactionManager s3TransactionManager;
+    private final ImageUploader imageUploader;
+
+    @Value("${cloud.aws.s3.folder}")
+    private String s3RootFolder;
 
     public StoreNearbyResult findNearbyStores(
             final Double latitude,
@@ -88,11 +96,11 @@ public class StoreService {
     }
 
     @Transactional
-    public StoreCreateResult addStore(final StoreCreateCommand command) {
+    public StoreCreateResult addStore(final StoreCreateCommand command, final List<MultipartFile> images) {
         Store store = command.toStore();
         Store savedStore = storeJpaRepository.save(store);
         storeDetailJpaRepository.save(command.toStoreDetail(savedStore));
-        storeImageJpaRepository.saveAll(command.toStoreImages(savedStore));
+        saveStoreImages(savedStore, images);
 
         return StoreCreateResult.from(savedStore);
     }
@@ -133,6 +141,32 @@ public class StoreService {
 
     public Store findByStoreId(final Long storeId) {
         return storeJpaRepository.getById(storeId);
+    }
+
+    private void saveStoreImages(final Store store, final List<MultipartFile> images) {
+        if (images == null || images.isEmpty()) {
+            return;
+        }
+
+        List<String> uploadedImageUrls = new ArrayList<>();
+        try {
+            List<StoreImage> storeImages = images.stream()
+                    .map(file -> {
+                        String imageUrl = imageUploader.upload(file, imagePath());
+                        uploadedImageUrls.add(imageUrl);
+                        return new StoreImage(store, imageUrl);
+                    })
+                    .toList();
+
+            storeImageJpaRepository.saveAll(storeImages);
+        } catch (RuntimeException e) {
+            uploadedImageUrls.forEach(imageUploader::delete);
+            throw e;
+        }
+    }
+
+    private String imagePath() {
+        return "%s/%s".formatted(s3RootFolder, ImageType.STORE.getFolderName());
     }
 
     private Map<Long, StoreDetail> findStoreDetails(final Page<Store> stores) {

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
@@ -228,11 +228,15 @@ public class StoreService {
     private void deleteStoreImagesFromS3(final Long storeId) {
         List<StoreImage> storeImages = storeImageJpaRepository.findAllByStoreId(storeId);
         for (StoreImage storeImage : storeImages) {
-            try {
-                imageUploader.delete(storeImage.getImageUrl());
-            } catch (RuntimeException e) {
-                log.warn("매장 삭제 중 S3 이미지 삭제에 실패했습니다. storeId={}, imageUrl={}", storeId, storeImage.getImageUrl(), e);
-            }
+            moveFileToTrash(storeId, storeImage);
+        }
+    }
+
+    private void moveFileToTrash(Long storeId, StoreImage storeImage) {
+        try {
+            imageUploader.delete(storeImage.getImageUrl());
+        } catch (RuntimeException e) {
+            log.warn("매장 삭제 중 S3 이미지 삭제에 실패했습니다. storeId={}, imageUrl={}", storeId, storeImage.getImageUrl(), e);
         }
     }
 

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
@@ -2,6 +2,7 @@ package com.gachi.gacha.server.store.application;
 
 import com.gachi.gacha.server.common.exception.ErrorCode;
 import com.gachi.gacha.server.common.exception.InvalidPageRequestException;
+import com.gachi.gacha.server.common.infra.exception.S3Exception;
 import com.gachi.gacha.server.store.application.dto.StoreCreateCommand;
 import com.gachi.gacha.server.store.application.dto.StoreCreateResult;
 import com.gachi.gacha.server.store.application.dto.StoreDeleteResult;
@@ -32,6 +33,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -120,11 +123,13 @@ public class StoreService {
     public StoreDeleteResult removeStore(final Long storeId) {
         Store store = storeJpaRepository.getById(storeId);
         StoreDetail storeDetail = storeDetailJpaRepository.getByStoreId(storeId);
+        List<StoreImage> storeImages = storeImageJpaRepository.findAllByStoreId(storeId);
 
-        deleteStoreImagesFromS3(storeId);
         storeImageJpaRepository.deleteAllByStoreId(storeId);
         storeDetailJpaRepository.delete(storeDetail);
         storeJpaRepository.delete(store);
+
+        registerStoreImageCleanupAfterCommit(storeId, storeImages);
 
         return StoreDeleteResult.from(store);
     }
@@ -225,17 +230,21 @@ public class StoreService {
         return result.s12;
     }
 
-    private void deleteStoreImagesFromS3(final Long storeId) {
-        List<StoreImage> storeImages = storeImageJpaRepository.findAllByStoreId(storeId);
-        for (StoreImage storeImage : storeImages) {
-            moveFileToTrash(storeId, storeImage);
-        }
+    private void registerStoreImageCleanupAfterCommit(final Long storeId, final List<StoreImage> storeImages) {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                for (StoreImage storeImage : storeImages) {
+                    deleteFile(storeId, storeImage);
+                }
+            }
+        });
     }
 
-    private void moveFileToTrash(Long storeId, StoreImage storeImage) {
+    private void deleteFile(final Long storeId, final StoreImage storeImage) {
         try {
             imageUploader.delete(storeImage.getImageUrl());
-        } catch (RuntimeException e) {
+        } catch (final S3Exception e) {
             log.warn("매장 삭제 중 S3 이미지 삭제에 실패했습니다. storeId={}, imageUrl={}", storeId, storeImage.getImageUrl(), e);
         }
     }

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/StoreService.java
@@ -149,20 +149,17 @@ public class StoreService {
         }
 
         List<String> uploadedImageUrls = new ArrayList<>();
-        try {
-            List<StoreImage> storeImages = images.stream()
-                    .map(file -> {
-                        String imageUrl = imageUploader.upload(file, imagePath());
-                        uploadedImageUrls.add(imageUrl);
-                        return new StoreImage(store, imageUrl);
-                    })
-                    .toList();
+        s3TransactionManager.deleteImagesOnRollback(ImageType.STORE, store.getId(), uploadedImageUrls);
 
-            storeImageJpaRepository.saveAll(storeImages);
-        } catch (RuntimeException e) {
-            uploadedImageUrls.forEach(imageUploader::delete);
-            throw e;
-        }
+        List<StoreImage> storeImages = images.stream()
+                .map(file -> {
+                    String imageUrl = imageUploader.upload(file, imagePath());
+                    uploadedImageUrls.add(imageUrl);
+                    return new StoreImage(store, imageUrl);
+                })
+                .toList();
+
+        storeImageJpaRepository.saveAll(storeImages);
     }
 
     private String imagePath() {

--- a/backend/src/main/java/com/gachi/gacha/server/store/application/dto/StoreCreateCommand.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/application/dto/StoreCreateCommand.java
@@ -4,7 +4,6 @@ import static com.gachi.gacha.server.common.util.BaseUtils.copyOrEmpty;
 
 import com.gachi.gacha.server.store.domain.Store;
 import com.gachi.gacha.server.store.domain.StoreDetail;
-import com.gachi.gacha.server.store.domain.StoreImage;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
@@ -31,13 +30,11 @@ public record StoreCreateCommand(
         Long selectGachaPriceMin,
         Long selectGachaPriceMax,
         List<String> facilities,
-        Boolean hasRandomBox,
-        List<String> imageUrls
+        Boolean hasRandomBox
 ) {
 
     public StoreCreateCommand {
         facilities = copyOrEmpty(facilities);
-        imageUrls = copyOrEmpty(imageUrls);
     }
 
     public Store toStore() {
@@ -70,12 +67,6 @@ public record StoreCreateCommand(
                 .hasRandomBox(hasRandomBox)
                 .hasSelectGacha(hasSelectGacha)
                 .build();
-    }
-
-    public List<StoreImage> toStoreImages(final Store store) {
-        return imageUrls.stream()
-                .map(imageUrl -> new StoreImage(store, imageUrl))
-                .toList();
     }
 
 }

--- a/backend/src/main/java/com/gachi/gacha/server/store/presentation/StoreController.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/presentation/StoreController.java
@@ -19,7 +19,7 @@ import com.gachi.gacha.server.store.presentation.dto.StoreListResponse;
 import com.gachi.gacha.server.store.presentation.dto.StoreNearbyResponse;
 import com.gachi.gacha.server.store.presentation.dto.StoreUpdateRequest;
 import com.gachi.gacha.server.store.presentation.dto.StoreUpdateResponse;
-import com.gachi.gacha.server.usecase.StoreGachaFacade;
+import com.gachi.gacha.server.usecase.application.StoreGachaFacade;
 import com.gachi.gacha.server.usecase.application.dto.GachaSummaryInfo;
 import jakarta.validation.Valid;
 import java.net.URI;

--- a/backend/src/main/java/com/gachi/gacha/server/store/presentation/StoreController.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/presentation/StoreController.java
@@ -23,11 +23,13 @@ import com.gachi.gacha.server.usecase.application.StoreGachaFacade;
 import com.gachi.gacha.server.usecase.application.dto.GachaSummaryInfo;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,7 +39,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
@@ -75,11 +79,12 @@ public class StoreController {
         return ResponseEntity.ok(BaseResponse.ok(StoreDetailResponse.from(result)));
     }
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BaseResponse<StoreCreateResponse>> createStore(
-            @Valid @RequestBody final StoreCreateRequest request
+            @Valid @RequestPart("request") final StoreCreateRequest request,
+            @RequestPart(value = "images", required = false) final List<MultipartFile> images
     ) {
-        StoreCreateResult result = storeService.addStore(request.toCommand());
+        StoreCreateResult result = storeService.addStore(request.toCommand(), images);
         StoreCreateResponse response = StoreCreateResponse.from(result);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()

--- a/backend/src/main/java/com/gachi/gacha/server/store/presentation/dto/StoreCreateRequest.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/presentation/dto/StoreCreateRequest.java
@@ -75,12 +75,7 @@ public record StoreCreateRequest(
 
         List<@NotBlank(message = "편의시설은 빈 값일 수 없습니다.") String> facilities,
 
-        Boolean hasRandomBox,
-
-        List<
-                @NotBlank(message = "이미지 URL은 빈 값일 수 없습니다.")
-                @Size(max = 255, message = "이미지 URL은 255자를 초과할 수 없습니다.")
-                        String> imageUrls
+        Boolean hasRandomBox
 ) {
 
     public StoreCreateCommand toCommand() {
@@ -106,7 +101,6 @@ public record StoreCreateRequest(
                 .selectGachaPriceMax(selectGachaPriceMax)
                 .facilities(facilities)
                 .hasRandomBox(hasRandomBox)
-                .imageUrls(imageUrls)
                 .build();
     }
 

--- a/backend/src/main/java/com/gachi/gacha/server/usecase/application/StoreGachaFacade.java
+++ b/backend/src/main/java/com/gachi/gacha/server/usecase/application/StoreGachaFacade.java
@@ -1,11 +1,10 @@
-package com.gachi.gacha.server.usecase;
+package com.gachi.gacha.server.usecase.application;
 
 import com.gachi.gacha.server.gacha.application.GachaService;
 import com.gachi.gacha.server.gacha.domain.Gacha;
 import com.gachi.gacha.server.store.application.StoreService;
 import com.gachi.gacha.server.store.application.dto.StoreGachaInfo;
 import com.gachi.gacha.server.store.domain.Store;
-import com.gachi.gacha.server.usecase.application.StoreGachaService;
 import com.gachi.gacha.server.usecase.application.dto.GachaSummaryInfo;
 import com.gachi.gacha.server.usecase.application.dto.StoreGachaCreatCommand;
 import com.gachi.gacha.server.usecase.application.dto.StoreGachaDeleteCommand;

--- a/backend/src/test/java/com/gachi/gacha/server/common/infra/config/ImageUploaderTest.java
+++ b/backend/src/test/java/com/gachi/gacha/server/common/infra/config/ImageUploaderTest.java
@@ -1,0 +1,64 @@
+package com.gachi.gacha.server.common.infra.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ImageUploaderTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    @Test
+    @DisplayName("moveToTrash는 최상위 폴더는 유지하고 그 다음 위치에 trash를 끼워 넣은 키로 복사 후 원본을 삭제한다.")
+    void moveToTrash_storePath() {
+        // given
+        ImageUploader imageUploader = new ImageUploader(s3Client);
+        ReflectionTestUtils.setField(imageUploader, "bucket", "test-bucket");
+        String imageUrl = "https://test-bucket.s3.amazonaws.com/gachigacha/store/abc-123.png";
+
+        // when
+        imageUploader.moveToTrash(imageUrl);
+
+        // then
+        ArgumentCaptor<CopyObjectRequest> copyCaptor = ArgumentCaptor.forClass(CopyObjectRequest.class);
+        verify(s3Client).copyObject(copyCaptor.capture());
+        CopyObjectRequest copyRequest = copyCaptor.getValue();
+        assertThat(copyRequest.sourceBucket()).isEqualTo("test-bucket");
+        assertThat(copyRequest.sourceKey()).isEqualTo("gachigacha/store/abc-123.png");
+        assertThat(copyRequest.destinationBucket()).isEqualTo("test-bucket");
+        assertThat(copyRequest.destinationKey()).isEqualTo("gachigacha/trash/store/abc-123.png");
+
+        ArgumentCaptor<DeleteObjectRequest> deleteCaptor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        verify(s3Client).deleteObject(deleteCaptor.capture());
+        assertThat(deleteCaptor.getValue().key()).isEqualTo("gachigacha/store/abc-123.png");
+    }
+
+    @Test
+    @DisplayName("가챠 이미지 경로도 동일한 규칙으로 trash 키를 만든다.")
+    void moveToTrash_gachaPath() {
+        // given
+        ImageUploader imageUploader = new ImageUploader(s3Client);
+        ReflectionTestUtils.setField(imageUploader, "bucket", "test-bucket");
+        String imageUrl = "https://test-bucket.s3.amazonaws.com/gachigacha/gacha/xyz-789.jpg";
+
+        // when
+        imageUploader.moveToTrash(imageUrl);
+
+        // then
+        ArgumentCaptor<CopyObjectRequest> copyCaptor = ArgumentCaptor.forClass(CopyObjectRequest.class);
+        verify(s3Client).copyObject(copyCaptor.capture());
+        assertThat(copyCaptor.getValue().destinationKey()).isEqualTo("gachigacha/trash/gacha/xyz-789.jpg");
+    }
+}

--- a/backend/src/test/java/com/gachi/gacha/server/common/util/S3TransactionManagerTest.java
+++ b/backend/src/test/java/com/gachi/gacha/server/common/util/S3TransactionManagerTest.java
@@ -1,0 +1,211 @@
+package com.gachi.gacha.server.common.util;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.gachi.gacha.server.common.infra.config.ImageType;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class S3TransactionManagerTest {
+
+    @Mock
+    private ImageUploader imageUploader;
+
+    private S3TransactionManager s3TransactionManager;
+
+    @BeforeEach
+    void setUp() {
+        s3TransactionManager = new S3TransactionManager(imageUploader);
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    @Nested
+    @DisplayName("cleanupAfterImageReplaced")
+    class CleanupAfterImageReplaced {
+
+        @Test
+        @DisplayName("커밋되면 옛 이미지를 휴지통으로 이동하고, 새 이미지는 건드리지 않는다.")
+        void commit_movesOldImageToTrash() {
+            // given
+            s3TransactionManager.cleanupAfterImageReplaced(ImageType.STORE, 1L, "old-url", "new-url");
+
+            // when
+            triggerAfterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+
+            // then
+            verify(imageUploader).moveToTrash("old-url");
+            verify(imageUploader, never()).delete("new-url");
+        }
+
+        @Test
+        @DisplayName("롤백되면 방금 올린 새 이미지를 삭제하고, 옛 이미지는 건드리지 않는다.")
+        void rollback_deletesNewImage() {
+            // given
+            s3TransactionManager.cleanupAfterImageReplaced(ImageType.STORE, 1L, "old-url", "new-url");
+
+            // when
+            triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            // then
+            verify(imageUploader).delete("new-url");
+            verify(imageUploader, never()).moveToTrash("old-url");
+        }
+
+        @Test
+        @DisplayName("S3 작업이 실패해도 예외가 밖으로 전파되지 않는다.")
+        void failure_doesNotPropagate() {
+            // given
+            doThrow(new RuntimeException("boom")).when(imageUploader).moveToTrash("old-url");
+            s3TransactionManager.cleanupAfterImageReplaced(ImageType.STORE, 1L, "old-url", "new-url");
+
+            // when & then
+            assertThatCode(() -> triggerAfterCompletion(TransactionSynchronization.STATUS_COMMITTED))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("trashImagesAfterRemoved")
+    class TrashImagesAfterRemoved {
+
+        @Test
+        @DisplayName("커밋되면 전달받은 이미지를 전부 휴지통으로 이동한다.")
+        void commit_movesAllImagesToTrash() {
+            // given
+            s3TransactionManager.trashImagesAfterRemoved(ImageType.GACHA, 1L, List.of("url-1", "url-2"));
+
+            // when
+            triggerAfterCommit();
+
+            // then
+            verify(imageUploader).moveToTrash("url-1");
+            verify(imageUploader).moveToTrash("url-2");
+        }
+
+        @Test
+        @DisplayName("롤백되면 아무 작업도 하지 않는다.")
+        void rollback_doesNothing() {
+            // given
+            s3TransactionManager.trashImagesAfterRemoved(ImageType.GACHA, 1L, List.of("url-1"));
+
+            // when
+            triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            // then
+            verify(imageUploader, never()).moveToTrash(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteImagesAfterRemoved")
+    class DeleteImagesAfterRemoved {
+
+        @Test
+        @DisplayName("커밋되면 전달받은 이미지를 전부 완전 삭제한다.")
+        void commit_deletesAllImages() {
+            // given
+            s3TransactionManager.deleteImagesAfterRemoved(ImageType.STORE, 1L, List.of("url-1", "url-2"));
+
+            // when
+            triggerAfterCommit();
+
+            // then
+            verify(imageUploader).delete("url-1");
+            verify(imageUploader).delete("url-2");
+            verify(imageUploader, never()).moveToTrash(anyString());
+        }
+
+        @Test
+        @DisplayName("롤백되면 아무 작업도 하지 않는다.")
+        void rollback_doesNothing() {
+            // given
+            s3TransactionManager.deleteImagesAfterRemoved(ImageType.STORE, 1L, List.of("url-1"));
+
+            // when
+            triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            // then
+            verify(imageUploader, never()).delete(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteImagesOnRollback")
+    class DeleteImagesOnRollback {
+
+        @Test
+        @DisplayName("커밋되면 아무 작업도 하지 않는다.")
+        void commit_doesNothing() {
+            // given
+            s3TransactionManager.deleteImagesOnRollback(ImageType.STORE, 1L, List.of("url-1"));
+
+            // when
+            triggerAfterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+
+            // then
+            verify(imageUploader, never()).delete(anyString());
+        }
+
+        @Test
+        @DisplayName("롤백되면 그 시점까지 업로드된 이미지를 전부 삭제한다.")
+        void rollback_deletesAllUploadedImages() {
+            // given: 등록 시점엔 비어있다가, 이후 실제 업로드가 진행되며 채워지는 리스트를 그대로 참조로 넘긴다.
+            List<String> uploadedImageUrls = new ArrayList<>();
+            s3TransactionManager.deleteImagesOnRollback(ImageType.STORE, 1L, uploadedImageUrls);
+            uploadedImageUrls.add("url-1");
+            uploadedImageUrls.add("url-2");
+
+            // when
+            triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            // then
+            verify(imageUploader).delete("url-1");
+            verify(imageUploader).delete("url-2");
+        }
+
+        @Test
+        @DisplayName("S3 삭제가 실패해도 예외가 밖으로 전파되지 않는다.")
+        void failure_doesNotPropagate() {
+            // given
+            doThrow(new RuntimeException("boom")).when(imageUploader).delete("url-1");
+            s3TransactionManager.deleteImagesOnRollback(ImageType.STORE, 1L, List.of("url-1"));
+
+            // when & then
+            assertThatCode(() -> triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    private void triggerAfterCommit() {
+        for (TransactionSynchronization synchronization : TransactionSynchronizationManager.getSynchronizations()) {
+            synchronization.afterCommit();
+        }
+    }
+
+    private void triggerAfterCompletion(final int status) {
+        for (TransactionSynchronization synchronization : TransactionSynchronizationManager.getSynchronizations()) {
+            synchronization.afterCompletion(status);
+        }
+    }
+}

--- a/backend/src/test/java/com/gachi/gacha/server/gacha/presentation/GachaImageControllerTest.java
+++ b/backend/src/test/java/com/gachi/gacha/server/gacha/presentation/GachaImageControllerTest.java
@@ -5,7 +5,7 @@ import com.gachi.gacha.server.common.exception.InvalidValueException;
 import com.gachi.gacha.server.gacha.domain.Gacha;
 import com.gachi.gacha.server.gacha.domain.GachaImageJpaRepository;
 import com.gachi.gacha.server.gacha.domain.GachaJpaRepository;
-import com.gachi.gacha.server.store.infra.config.ImageUploader;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;

--- a/backend/src/test/java/com/gachi/gacha/server/gacha/presentation/GachaImageControllerTest.java
+++ b/backend/src/test/java/com/gachi/gacha/server/gacha/presentation/GachaImageControllerTest.java
@@ -1,0 +1,310 @@
+package com.gachi.gacha.server.gacha.presentation;
+
+import com.gachi.gacha.server.common.exception.ErrorCode;
+import com.gachi.gacha.server.common.exception.InvalidValueException;
+import com.gachi.gacha.server.gacha.domain.Gacha;
+import com.gachi.gacha.server.gacha.domain.GachaImageJpaRepository;
+import com.gachi.gacha.server.gacha.domain.GachaJpaRepository;
+import com.gachi.gacha.server.store.infra.config.ImageUploader;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class GachaImageControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private GachaJpaRepository gachaRepository;
+
+    @Autowired
+    private GachaImageJpaRepository gachaImageRepository;
+
+    @MockitoBean
+    private ImageUploader imageUploader;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        when(imageUploader.upload(any(), anyString()))
+                .thenReturn("https://example.com/gachas/test-image.jpg");
+        doNothing().when(imageUploader).delete(anyString());
+    }
+
+    @Nested
+    @DisplayName("GET /gachas/{gachaId}/images - 가챠 이미지 목록 조회 API")
+    class FindImages {
+
+        @Test
+        @DisplayName("등록된 이미지가 있으면 200 OK와 이미지 목록을 반환한다.")
+        void findImages_success() {
+            // given
+            Long gachaId = createTargetGacha();
+            createTargetGachaImage(gachaId);
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .when()
+                    .get("/api/v1/gachas/{gachaId}/images", gachaId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.jsonPath().getString("code")).isEqualTo("C000");
+            assertThat(response.jsonPath().getList("data.items")).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 가챠면 404 Not Found를 반환한다.")
+        void findImages_gachaNotFound() {
+            // given
+            Long nonExistentGachaId = 999999L;
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .when()
+                    .get("/api/v1/gachas/{gachaId}/images", nonExistentGachaId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /gachas/{gachaId}/images - 가챠 이미지 등록 API")
+    class AddImage {
+
+        @Test
+        @DisplayName("이미지 파일 하나를 첨부해 요청하면 201 Created와 등록된 이미지 목록을 반환한다.")
+        void addImage_success() {
+            // given
+            Long gachaId = createTargetGacha();
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .multiPart("images", "image.png", "dummy-image-content".getBytes(), "image/png")
+                    .when()
+                    .post("/api/v1/gachas/{gachaId}/images", gachaId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+            assertThat(response.jsonPath().getString("code")).isEqualTo("C001");
+            assertThat(response.jsonPath().getList("data.items")).hasSize(1);
+            assertThat(response.jsonPath().getLong("data.items[0].gachaImageId")).isNotNull();
+        }
+
+        @Test
+        @DisplayName("이미지 파일 여러 개를 첨부해 요청하면 201 Created와 등록된 이미지 목록을 모두 반환한다.")
+        void addImage_multiple_success() {
+            // given
+            Long gachaId = createTargetGacha();
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .multiPart("images", "image1.png", "dummy-image-content-1".getBytes(), "image/png")
+                    .multiPart("images", "image2.png", "dummy-image-content-2".getBytes(), "image/png")
+                    .multiPart("images", "image3.png", "dummy-image-content-3".getBytes(), "image/png")
+                    .when()
+                    .post("/api/v1/gachas/{gachaId}/images", gachaId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+            assertThat(response.jsonPath().getList("data.items")).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("업로드 중 하나라도 실패하면 이미 업로드된 이미지도 정리되고 전부 등록되지 않는다.")
+        void addImage_partialFailure_rollsBackAll() {
+            // given
+            Long gachaId = createTargetGacha();
+
+            when(imageUploader.upload(
+                    argThat((MultipartFile file) -> file != null && "invalid.png".equals(file.getOriginalFilename())),
+                    anyString()
+            )).thenThrow(new InvalidValueException(ErrorCode.INVALID_GACHA_IMAGE_POLICY));
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .multiPart("images", "image1.png", "dummy-image-content-1".getBytes(), "image/png")
+                    .multiPart("images", "invalid.png", "dummy-image-content-2".getBytes(), "image/png")
+                    .multiPart("images", "image3.png", "dummy-image-content-3".getBytes(), "image/png")
+                    .when()
+                    .post("/api/v1/gachas/{gachaId}/images", gachaId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+            assertThat(gachaImageRepository.findAllByGachaId(gachaId)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 가챠면 404 Not Found를 반환한다.")
+        void addImage_gachaNotFound() {
+            // given
+            Long nonExistentGachaId = 999999L;
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .multiPart("images", "image.png", "dummy-image-content".getBytes(), "image/png")
+                    .when()
+                    .post("/api/v1/gachas/{gachaId}/images", nonExistentGachaId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        }
+
+        @Test
+        @DisplayName("images 파트 없이 요청하면 400 Bad Request를 반환한다.")
+        void addImage_missingImagePart() {
+            // given
+            Long gachaId = createTargetGacha();
+
+            // when - 'images'가 아닌 다른 파트명으로 전송
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .multiPart("file", "image.png", "dummy-image-content".getBytes(), "image/png")
+                    .when()
+                    .post("/api/v1/gachas/{gachaId}/images", gachaId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /gachas/{gachaId}/images/{gachaImageId} - 가챠 이미지 수정 API")
+    class ModifyImage {
+
+        @Test
+        @DisplayName("이미지 수정에 성공하면 200 OK를 반환한다.")
+        void modifyImage_success() {
+            // given
+            Long gachaId = createTargetGacha();
+            Long gachaImageId = createTargetGachaImage(gachaId);
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .multiPart("image", "new-image.png", "new-dummy-content".getBytes(), "image/png")
+                    .when()
+                    .put("/api/v1/gachas/{gachaId}/images/{gachaImageId}", gachaId, gachaImageId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.jsonPath().getString("code")).isEqualTo("C002");
+            assertThat(response.jsonPath().getLong("data.gachaImageId")).isEqualTo(gachaImageId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이미지면 404 Not Found를 반환한다.")
+        void modifyImage_notFound() {
+            // given
+            Long gachaId = createTargetGacha();
+            Long nonExistentImageId = 999999L;
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .multiPart("image", "new-image.png", "new-dummy-content".getBytes(), "image/png")
+                    .when()
+                    .put("/api/v1/gachas/{gachaId}/images/{gachaImageId}", gachaId, nonExistentImageId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /gachas/{gachaId}/images/{gachaImageId} - 가챠 이미지 삭제 API")
+    class RemoveImage {
+
+        @Test
+        @DisplayName("이미지 삭제에 성공하면 200 OK를 반환한다.")
+        void removeImage_success() {
+            // given
+            Long gachaId = createTargetGacha();
+            Long gachaImageId = createTargetGachaImage(gachaId);
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .when()
+                    .delete("/api/v1/gachas/{gachaId}/images/{gachaImageId}", gachaId, gachaImageId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.jsonPath().getString("code")).isEqualTo("C003");
+            assertThat(response.jsonPath().getLong("data.gachaImageId")).isEqualTo(gachaImageId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이미지면 404 Not Found를 반환한다.")
+        void removeImage_notFound() {
+            // given
+            Long gachaId = createTargetGacha();
+            Long nonExistentImageId = 999999L;
+
+            // when
+            ExtractableResponse<Response> response = RestAssured.given().log().all()
+                    .when()
+                    .delete("/api/v1/gachas/{gachaId}/images/{gachaImageId}", gachaId, nonExistentImageId)
+                    .then().log().all()
+                    .extract();
+
+            // then
+            assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        }
+    }
+
+    private Long createTargetGacha() {
+        Gacha gacha = Gacha.builder()
+                .name("테스트 가챠")
+                .caption("가챠 설명")
+                .thumbnailUrl("https://example.com/image.png")
+                .build();
+
+        return gachaRepository.save(gacha).getId();
+    }
+
+    private Long createTargetGachaImage(final Long gachaId) {
+        return RestAssured.given()
+                .multiPart("images", "seed-image.png", "seed-dummy-content".getBytes(), "image/png")
+                .when()
+                .post("/api/v1/gachas/{gachaId}/images", gachaId)
+                .jsonPath()
+                .getLong("data.items[0].gachaImageId");
+    }
+}

--- a/backend/src/test/java/com/gachi/gacha/server/gacha/presentation/GachaImageControllerTest.java
+++ b/backend/src/test/java/com/gachi/gacha/server/gacha/presentation/GachaImageControllerTest.java
@@ -48,6 +48,7 @@ class GachaImageControllerTest {
         when(imageUploader.upload(any(), anyString()))
                 .thenReturn("https://example.com/gachas/test-image.jpg");
         doNothing().when(imageUploader).delete(anyString());
+        doNothing().when(imageUploader).moveToTrash(anyString());
     }
 
     @Nested

--- a/backend/src/test/java/com/gachi/gacha/server/store/presentation/StoreControllerTest.java
+++ b/backend/src/test/java/com/gachi/gacha/server/store/presentation/StoreControllerTest.java
@@ -1,7 +1,12 @@
 package com.gachi.gacha.server.store.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
@@ -16,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -26,12 +32,19 @@ class StoreControllerTest {
     private static final double STORE_LATITUDE = 37.5299;
     private static final double STORE_LONGITUDE = 126.9648;
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     @LocalServerPort
     private int port;
+
+    @MockitoBean
+    private ImageUploader imageUploader;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+        when(imageUploader.upload(any(), anyString()))
+                .thenReturn("https://example.com/stores/test-image.jpg");
     }
 
     @Nested
@@ -475,17 +488,20 @@ class StoreControllerTest {
         request.put("selectGachaPriceMax", 10_000);
         request.put("facilities", List.of("동전교환기"));
         request.put("hasRandomBox", false);
-        request.put("imageUrls", List.of("https://example.com/store-image.png"));
         return request;
     }
 
     private ExtractableResponse<Response> requestCreateStore(final Map<String, Object> request) {
-        return RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .body(request)
-                .when()
-                .post("/api/v1/stores")
-                .then().log().all()
-                .extract();
+        try {
+            return RestAssured.given().log().all()
+                    .multiPart("request", "request.json", OBJECT_MAPPER.writeValueAsBytes(request), "application/json")
+                    .multiPart("images", "store-image.png", "dummy-image-content".getBytes(), "image/png")
+                    .when()
+                    .post("/api/v1/stores")
+                    .then().log().all()
+                    .extract();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/backend/src/test/java/com/gachi/gacha/server/store/presentation/StoreImageControllerTest.java
+++ b/backend/src/test/java/com/gachi/gacha/server/store/presentation/StoreImageControllerTest.java
@@ -48,6 +48,7 @@ class StoreImageControllerTest {
         when(imageUploader.upload(any(), anyString()))
                 .thenReturn("https://example.com/stores/test-image.jpg");
         doNothing().when(imageUploader).delete(anyString());
+        doNothing().when(imageUploader).moveToTrash(anyString());
     }
 
     @Nested

--- a/backend/src/test/java/com/gachi/gacha/server/store/presentation/StoreImageControllerTest.java
+++ b/backend/src/test/java/com/gachi/gacha/server/store/presentation/StoreImageControllerTest.java
@@ -5,7 +5,7 @@ import com.gachi.gacha.server.common.exception.InvalidValueException;
 import com.gachi.gacha.server.store.domain.Store;
 import com.gachi.gacha.server.store.domain.StoreImageJpaRepository;
 import com.gachi.gacha.server.store.domain.StoreJpaRepository;
-import com.gachi.gacha.server.store.infra.config.ImageUploader;
+import com.gachi.gacha.server.common.infra.config.ImageUploader;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->
- 가챠 이미지 목록 조회
- 가챠 이미지 등록
- 가챠 이미지 수정·삭제

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #21

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->

## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [ ] 포매터·린터를 통과했다
- [x] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다
