### PR TITLE
[FEAT] 매장 상세 페이지에 가챠 이미지 갤러리 추가

### DIFF
--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.stories.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
+import defaultStoreThumbnail from '@/assets/defaultStoreThumbnail.png';
+
 import StoreDetailSheet from './StoreDetailSheet';
 import * as S from './StoreDetailSheet.styles';
 import StoreDetailSheetContainer from './StoreDetailSheetContainer';
@@ -8,6 +10,22 @@ import { mockStoreDetail } from '../mocks/storeDetail.mock';
 import { toStoreDetail } from '../model/toStoreDetail';
 
 const store = toStoreDetail(mockStoreDetail, { distanceMeters: 380 });
+const storeWithGallery = toStoreDetail(
+  {
+    ...mockStoreDetail,
+    images: Array.from({ length: 5 }, (_, index) => ({
+      storeImageId: index + 1,
+      imageUrl: `${defaultStoreThumbnail}?store=${index + 1}`,
+    })),
+  },
+  {
+    distanceMeters: 380,
+    gachaImageUrls: Array.from(
+      { length: 8 },
+      (_, index) => `${defaultStoreThumbnail}?gacha=${index + 1}`,
+    ),
+  },
+);
 const doNothing = () => undefined;
 
 function PinClickDemo() {
@@ -71,6 +89,18 @@ export const SuccessWithoutImage: Story = {
       state="full"
       status="success"
       store={store}
+      onClose={doNothing}
+      onStateChange={doNothing}
+    />
+  ),
+};
+
+export const GalleryWithGachaImages: Story = {
+  render: () => (
+    <StoreDetailSheet
+      state="full"
+      status="success"
+      store={storeWithGallery}
       onClose={doNothing}
       onStateChange={doNothing}
     />

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
@@ -316,12 +316,36 @@ export const PhotoSection = styled.section<{ $state: BottomSheetState }>`
 
 export const PhotoTitleRow = styled.div`
   display: flex;
-  gap: 16px;
+  gap: 12px;
   align-items: center;
   justify-content: space-between;
+`;
 
-  h3 {
-    margin-bottom: 0;
+export const GalleryTabs = styled.div`
+  display: flex;
+  min-width: 0;
+  padding: 3px;
+  background: #f8f1f4;
+  border-radius: 12px;
+`;
+
+export const GalleryTab = styled.button<{ $isActive: boolean }>`
+  min-height: 34px;
+  padding: 7px 11px;
+  color: ${({ $isActive }) => ($isActive ? '#7f3150' : '#87777d')};
+  font-size: 13px;
+  font-weight: 750;
+  white-space: nowrap;
+  cursor: pointer;
+  background: ${({ $isActive }) => ($isActive ? '#ffffff' : 'transparent')};
+  border: 0;
+  border-radius: 9px;
+  box-shadow: ${({ $isActive }) =>
+    $isActive ? '0 2px 8px rgb(98 56 71 / 10%)' : 'none'};
+
+  &:focus-visible {
+    outline: 3px solid rgb(180 73 113 / 24%);
+    outline-offset: 1px;
   }
 `;
 
@@ -329,6 +353,33 @@ export const GalleryControls = styled.div`
   display: flex;
   gap: 7px;
   align-items: center;
+`;
+
+export const GalleryViewButton = styled.button`
+  min-height: 32px;
+  padding: 6px 9px;
+  color: #8a4861;
+  font-size: 12px;
+  font-weight: 750;
+  white-space: nowrap;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  border-radius: 9px;
+
+  &:hover:not(:disabled) {
+    background: #fff0f5;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.4;
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgb(180 73 113 / 24%);
+    outline-offset: 1px;
+  }
 `;
 
 export const GalleryControl = styled.button`
@@ -407,6 +458,21 @@ export const ThumbnailFrame = styled.div`
   border-radius: 17px;
   scroll-snap-align: start;
   scroll-snap-stop: always;
+`;
+
+export const PhotoGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+  margin-top: 15px;
+`;
+
+export const GridImageFrame = styled.div`
+  overflow: hidden;
+  aspect-ratio: 1;
+  background: #faf3f5;
+  border: 1px solid #f0e3e7;
+  border-radius: 14px;
 `;
 
 export const ThumbnailImage = styled.img`

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
@@ -51,30 +51,56 @@ export type StoreDetailSheetProps =
 
 const FALLBACK_THUMBNAILS = [null, null, null] as const;
 
-interface StoreThumbnailProps {
+type GalleryKind = 'store' | 'gacha';
+
+const GALLERY_CONFIG: Record<
+  GalleryKind,
+  { label: string; imageLabel: string; placeholder: string }
+> = {
+  store: {
+    label: '매장 사진',
+    imageLabel: '매장 사진',
+    placeholder: '매장 사진 준비 중',
+  },
+  gacha: {
+    label: '가챠 목록',
+    imageLabel: '가챠 사진',
+    placeholder: '가챠 사진 준비 중',
+  },
+};
+
+interface GalleryThumbnailProps {
   imageUrl: string | null;
+  imageLabel: string;
   index: number;
+  placeholder: string;
   storeName: string;
 }
 
-function StoreThumbnail({ imageUrl, index, storeName }: StoreThumbnailProps) {
+function GalleryThumbnail({
+  imageUrl,
+  imageLabel,
+  index,
+  placeholder,
+  storeName,
+}: GalleryThumbnailProps) {
   const [hasImageError, setHasImageError] = useState(false);
 
   if (!imageUrl || hasImageError) {
     return (
       <S.ThumbnailPlaceholder
-        aria-label={`${storeName} 매장 사진 ${index + 1} 준비 중`}
+        aria-label={`${storeName} ${imageLabel} ${index + 1} 준비 중`}
         role="img"
       >
         <S.ThumbnailPlaceholderMark aria-hidden="true" />
-        <span>매장 사진 준비 중</span>
+        <span>{placeholder}</span>
       </S.ThumbnailPlaceholder>
     );
   }
 
   return (
     <S.ThumbnailImage
-      alt={`${storeName} 매장 사진 ${index + 1}`}
+      alt={`${storeName} ${imageLabel} ${index + 1}`}
       draggable={false}
       src={imageUrl}
       onError={() => setHasImageError(true)}
@@ -83,8 +109,9 @@ function StoreThumbnail({ imageUrl, index, storeName }: StoreThumbnailProps) {
 }
 
 interface StoreGalleryProps {
-  imageUrls: string[];
+  gachaImageUrls: string[];
   state: BottomSheetState;
+  storeImageUrls: string[];
   storeName: string;
 }
 
@@ -101,7 +128,17 @@ function getFrameScrollLeft(frame: HTMLElement, rail: HTMLElement) {
   return frame.offsetLeft - (firstFrame?.offsetLeft ?? 0);
 }
 
-function StoreGallery({ imageUrls, state, storeName }: StoreGalleryProps) {
+function StoreGallery({
+  gachaImageUrls,
+  state,
+  storeImageUrls,
+  storeName,
+}: StoreGalleryProps) {
+  const tabPanelId = useId();
+  const [galleryKind, setGalleryKind] = useState<GalleryKind>('store');
+  const [showAll, setShowAll] = useState(false);
+  const imageUrls = galleryKind === 'store' ? storeImageUrls : gachaImageUrls;
+  const galleryConfig = GALLERY_CONFIG[galleryKind];
   const thumbnails = imageUrls.length > 0 ? imageUrls : FALLBACK_THUMBNAILS;
   const railRef = useRef<HTMLDivElement>(null);
   const dragStartRef = useRef<GalleryDragStart | null>(null);
@@ -146,7 +183,18 @@ function StoreGallery({ imageUrls, state, storeName }: StoreGalleryProps) {
     resizeObserver.observe(rail);
 
     return () => resizeObserver.disconnect();
-  }, [thumbnails.length, updateSlideControls]);
+  }, [showAll, thumbnails.length, updateSlideControls]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+    setCanSlideLeft(false);
+    setShowAll(false);
+    railRef.current?.scrollTo({ left: 0 });
+  }, [galleryKind]);
+
+  useEffect(() => {
+    if (state !== 'full') setShowAll(false);
+  }, [state]);
 
   const slide = (direction: -1 | 1) => {
     const rail = railRef.current;
@@ -236,49 +284,108 @@ function StoreGallery({ imageUrls, state, storeName }: StoreGalleryProps) {
   return (
     <S.PhotoSection $state={state}>
       <S.PhotoTitleRow>
-        <S.SectionTitle>매장 사진</S.SectionTitle>
-        <S.GalleryControls aria-label="매장 사진 이동" role="group">
-          <S.GalleryControl
-            aria-label="이전 매장 사진"
-            disabled={!canSlideLeft}
-            type="button"
-            onClick={() => slide(-1)}
-          >
-            ‹
-          </S.GalleryControl>
-          <S.GalleryControl
-            aria-label="다음 매장 사진"
-            disabled={!canSlideRight}
-            type="button"
-            onClick={() => slide(1)}
-          >
-            ›
-          </S.GalleryControl>
+        <S.GalleryTabs aria-label="사진 종류" role="tablist">
+          {(Object.keys(GALLERY_CONFIG) as GalleryKind[]).map((kind) => (
+            <S.GalleryTab
+              key={kind}
+              $isActive={galleryKind === kind}
+              aria-controls={tabPanelId}
+              aria-selected={galleryKind === kind}
+              role="tab"
+              type="button"
+              onClick={() => setGalleryKind(kind)}
+            >
+              {GALLERY_CONFIG[kind].label}
+            </S.GalleryTab>
+          ))}
+        </S.GalleryTabs>
+        <S.GalleryControls
+          aria-label={`${galleryConfig.label} 보기`}
+          role="group"
+        >
+          {state === 'full' && (
+            <S.GalleryViewButton
+              disabled={imageUrls.length === 0}
+              type="button"
+              onClick={() => setShowAll((isShowingAll) => !isShowingAll)}
+            >
+              {showAll ? '미리보기' : '더보기'}
+            </S.GalleryViewButton>
+          )}
+          {!showAll && (
+            <>
+              <S.GalleryControl
+                aria-label={`이전 ${galleryConfig.imageLabel}`}
+                disabled={!canSlideLeft}
+                type="button"
+                onClick={() => slide(-1)}
+              >
+                ‹
+              </S.GalleryControl>
+              <S.GalleryControl
+                aria-label={`다음 ${galleryConfig.imageLabel}`}
+                disabled={!canSlideRight}
+                type="button"
+                onClick={() => slide(1)}
+              >
+                ›
+              </S.GalleryControl>
+            </>
+          )}
         </S.GalleryControls>
       </S.PhotoTitleRow>
-      <S.GalleryViewport $state={state}>
-        <S.ThumbnailRail
-          ref={railRef}
-          $isDragging={isDragging}
-          aria-label="매장 사진 목록"
-          data-horizontal-scroll
-          onPointerCancel={finishGalleryDrag}
-          onPointerDown={handleGalleryPointerDown}
-          onPointerMove={handleGalleryPointerMove}
-          onPointerUp={finishGalleryDrag}
-          onScroll={updateSlideControls}
+      {showAll ? (
+        <S.PhotoGrid
+          id={tabPanelId}
+          aria-label={`${galleryConfig.label} 전체 보기`}
+          role="tabpanel"
         >
-          {thumbnails.map((imageUrl, index) => (
-            <S.ThumbnailFrame key={imageUrl ?? `fallback-${index}`}>
-              <StoreThumbnail
+          {imageUrls.map((imageUrl, index) => (
+            <S.GridImageFrame key={imageUrl}>
+              <GalleryThumbnail
+                imageLabel={galleryConfig.imageLabel}
                 imageUrl={imageUrl}
                 index={index}
+                placeholder={galleryConfig.placeholder}
                 storeName={storeName}
               />
-            </S.ThumbnailFrame>
+            </S.GridImageFrame>
           ))}
-        </S.ThumbnailRail>
-      </S.GalleryViewport>
+        </S.PhotoGrid>
+      ) : (
+        <S.GalleryViewport
+          id={tabPanelId}
+          $state={state}
+          aria-label={galleryConfig.label}
+          role="tabpanel"
+        >
+          <S.ThumbnailRail
+            ref={railRef}
+            $isDragging={isDragging}
+            aria-label={galleryConfig.label}
+            data-horizontal-scroll
+            onPointerCancel={finishGalleryDrag}
+            onPointerDown={handleGalleryPointerDown}
+            onPointerMove={handleGalleryPointerMove}
+            onPointerUp={finishGalleryDrag}
+            onScroll={updateSlideControls}
+          >
+            {thumbnails.map((imageUrl, index) => (
+              <S.ThumbnailFrame
+                key={`${galleryKind}-${imageUrl ?? `fallback-${index}`}`}
+              >
+                <GalleryThumbnail
+                  imageLabel={galleryConfig.imageLabel}
+                  imageUrl={imageUrl}
+                  index={index}
+                  placeholder={galleryConfig.placeholder}
+                  storeName={storeName}
+                />
+              </S.ThumbnailFrame>
+            ))}
+          </S.ThumbnailRail>
+        </S.GalleryViewport>
+      )}
     </S.PhotoSection>
   );
 }
@@ -433,8 +540,9 @@ function StoreDetailContent({
         )}
 
         <StoreGallery
-          imageUrls={store.imageUrls}
+          gachaImageUrls={store.gachaImageUrls}
           state={state}
+          storeImageUrls={store.imageUrls}
           storeName={store.name}
         />
 

--- a/frontend/src/features/storeDetail/model/storeDetail.ts
+++ b/frontend/src/features/storeDetail/model/storeDetail.ts
@@ -16,6 +16,7 @@ export interface StoreDetail {
   address: string;
   businessHours: string;
   imageUrls: string[];
+  gachaImageUrls: string[];
   phone: string | null;
   socialLinks: StoreDetailSocialLink[];
   categories: string[];

--- a/frontend/src/features/storeDetail/model/toStoreDetail.ts
+++ b/frontend/src/features/storeDetail/model/toStoreDetail.ts
@@ -7,6 +7,7 @@ import type { StoreDetailDto } from '../api/storeDetail.dto';
 
 interface ToStoreDetailOptions {
   distanceMeters?: number;
+  gachaImageUrls?: string[];
 }
 
 const AMOUNT_RANGES = [
@@ -164,6 +165,7 @@ export function toStoreDetail(
     address: dto.address,
     businessHours: dto.businessHours ?? '정보 없음',
     imageUrls,
+    gachaImageUrls: Array.from(new Set(options.gachaImageUrls ?? [])),
     phone: dto.phoneNumber,
     socialLinks: instagram ? [instagram] : [],
     categories: createCategories(dto),


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->

매장 상세 화면에서 매장 사진과 해당 매장이 보유한 가챠 이미지를 탭으로 구분해 확인할 수 있는 이미지 갤러리를 추가

- `StoreDetail` 화면 모델에 `gachaImageUrls`를 추가
- API 계약이 확정되기 전에도 별도의 가챠 이미지 URL 목록을 주입할 수 있도록 매퍼 연결 지점을 구성
- 중복된 가챠 이미지 URL을 제거하도록 처리
- 매장 사진과 가챠 목록을 전환할 수 있는 탭을 추가
- 선택된 탭의 이미지를 가로 슬라이드로 표시
- 이전, 다음 버튼과 포인터 드래그를 통한 이미지 탐색을 지원
- 탭을 전환하면 슬라이드 위치와 전체보기 상태가 초기화
- 전체 상태의 바텀시트에서 더보기 버튼을 제공
- 더보기 선택 시 전체 이미지를 2열 앨범 그리드로 표시
- 미리보기 선택 시 가로 슬라이드 화면으로 돌아감
- 바텀시트가 축소되면 전체보기 상태를 해제
- 이미지가 없거나 로딩에 실패한 경우 탭 종류에 맞는 준비 중 UI를 표시
- 매장 사진과 가챠 이미지가 모두 존재하는 상태를 확인할 수 있도록 Storybook 시나리오를 추가

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #39 

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->
<img width="852" height="903" alt="image" src="https://github.com/user-attachments/assets/ac6987a6-45a8-4ab1-a202-f076900257ad" />

## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->
- 백엔드의 가챠 이미지 API 계약이 아직 확정되지 않아, DTO 필드명을 임의로 추가하지 않고 `toStoreDetail` 옵션으로 `gachaImageUrls`를 주입할 수 있도록 구성
- API 계약이 확정되면 컨테이너에서 실제 가챠 이미지 목록을 조회하고 매퍼에 전달하는 부분만 연결할 예정
- 매장 사진과 가챠 이미지의 UI 동작을 재사용할 수 있도록 하나의 갤러리 컴포넌트에서 선택된 탭의 이미지 목록을 처리
- 더보기 화면을 별도 모달이나 페이지가 아닌 기존 바텀시트 내부의 2열 그리드로 구현. 이미지 수가 많아질 경우 별도 화면이나 페이지네이션이 필요한지 무한 스크롤로 할지 등 상세수치 의견 공유 필요
- 탭 변경이나 바텀시트 축소 후 이전 전체보기 상태가 남지 않도록 상태를 초기화
- 이미지 URL이 중복 제공될 가능성을 고려하여 화면 모델 변환 단계에서 중복을 제거
- 현재 가챠 이미지가 없는 운영 데이터에서는 준비 중 UI가 표시. 이미지가 존재하는 상태는 `GalleryWithGachaImages` Storybook 스토리에서 확인가능
- 인스타그램 원본 이미지 URL은 만료될 가능성이 있어, 추후 백엔드에서 S3 등에 저장한 HTTPS 섬네일 URL을 제공받는 방향을 고려할 필요

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [x] 포매터·린터를 통과했다
- [x] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다
