### PR TITLE
[REFACTOR]: 지도 마커 겹침과 시트 가림 개선

### DIFF
--- a/frontend/src/components/kakaoMap/StoreMarker.tsx
+++ b/frontend/src/components/kakaoMap/StoreMarker.tsx
@@ -18,6 +18,8 @@ function createMarkerImage(isSelected: boolean) {
     new maps.Size(icon.width, icon.height),
     {
       offset: new maps.Point(icon.anchorX, icon.anchorY),
+      shape: icon.hitShape,
+      coords: icon.hitCoords,
     },
   );
 }

--- a/frontend/src/components/kakaoMap/markerIcon.ts
+++ b/frontend/src/components/kakaoMap/markerIcon.ts
@@ -8,16 +8,21 @@
  *   결과를 재사용하므로, 마커가 몇 개든 실제 래스터는 상태당 한 번이다.
  * - 두 상태의 배율과 기준점은 아래 상수에서 계산한다. 손으로 맞추면
  *   선택할 때 마커가 튄다.
+ * - 그림자는 넣지 않는다. 그림자가 있으면 기준점을 지면에 둬야 해서 캡슐이
+ *   좌표 위쪽에 뜨고, 이미지 박스도 아래로 길어져 클릭 영역이 넓어진다.
  */
 
-/** 도안의 기준 배율. 닫힘 상태의 viewBox 40.8단위를 40px로 그린다. */
-const BASE_VIEWBOX_WIDTH = 40.8;
-const BASE_RENDER_WIDTH = 40;
-const SCALE = BASE_RENDER_WIDTH / BASE_VIEWBOX_WIDTH;
-
-/** 두 상태가 공유하는 기준점 (도안 좌표계). 그릇의 중심축과 지면에 닿는 높이. */
+/** 캡슐 원 (도안 좌표계). 마커의 모든 치수가 여기서 나온다. */
 const CENTER_X = 20;
-const GROUND_Y = 51.5;
+const CENTER_Y = 28;
+const RADIUS = 17;
+const OUTLINE_WIDTH = 1.4;
+/** 외곽선은 경로 중앙에 그려지므로 절반이 원 바깥으로 나간다. */
+const EDGE = OUTLINE_WIDTH / 2;
+
+/** 캡슐 지름을 화면에서 몇 px로 그릴지. 마커 크기는 이 값 하나가 정한다. */
+const BALL_RENDER_DIAMETER = 24;
+const SCALE = BALL_RENDER_DIAMETER / (RADIUS * 2);
 
 /**
  * 뚜껑이 맞물리는 선(씰)이 반지름 17 원과 만나는 두 점.
@@ -51,52 +56,56 @@ interface MarkerArt {
   body: string;
 }
 
-const SHADOW_GRADIENT = `<radialGradient id="s">
-  <stop offset="0%" stop-color="${OUTLINE}" stop-opacity=".24"/>
-  <stop offset="55%" stop-color="${OUTLINE}" stop-opacity=".149"/>
-  <stop offset="100%" stop-color="${OUTLINE}" stop-opacity="0"/>
-</radialGradient>`;
-
-const SHADOW = `<ellipse cx="${CENTER_X}" cy="${GROUND_Y}" rx="7.4" ry="2.5" fill="url(#s)"/>`;
-
 /** 그릇 위쪽에 걸치는 반투명 띠. 뚜껑이 맞물린 자리를 표현한다. */
 const SEAM_BAND = `<g transform="rotate(-14 20 28)"><rect x="-40" y="29" width="120" height="4" fill="${GLASS}" opacity=".5"/></g>`;
 
 /** 유리 뚜껑의 하이라이트 호. */
 const HIGHLIGHT = `<path d="M 8.22 21.20 A 13.6 13.6 0 0 1 18.81 14.45" fill="none" stroke="#fff" stroke-width="2.6" stroke-linecap="round" opacity=".9"/>`;
 
+const BALL_PATH = `M ${CENTER_X} ${CENTER_Y - RADIUS} A ${RADIUS} ${RADIUS} 0 1 1 ${CENTER_X - 0.01} ${CENTER_Y - RADIUS} Z`;
+
+/** 닫힘 상태는 원에 외곽선 절반을 더한 정사각형이면 정확히 들어맞는다. */
 const CLOSED: MarkerArt = {
-  viewBox: { x: -0.4, y: 9, width: 40.8, height: 47.7 },
-  defs: `${SHADOW_GRADIENT}
-<clipPath id="a"><path d="M 20 11 A 17 17 0 1 1 19.99 11 Z"/></clipPath>`,
-  body: `${SHADOW}
-<g clip-path="url(#a)">
+  viewBox: {
+    x: CENTER_X - RADIUS - EDGE,
+    y: CENTER_Y - RADIUS - EDGE,
+    width: (RADIUS + EDGE) * 2,
+    height: (RADIUS + EDGE) * 2,
+  },
+  defs: `<clipPath id="a"><path d="${BALL_PATH}"/></clipPath>`,
+  body: `<g clip-path="url(#a)">
   <rect x="-40" y="-60" width="120" height="180" fill="${ORANGE}"/>
   <g transform="rotate(-14 20 28)"><rect x="-40" y="-51" width="120" height="80" fill="${GLASS}"/></g>
   ${SEAM_BAND}
 </g>
 ${HIGHLIGHT}
-<path d="M 20 11 A 17 17 0 1 1 19.99 11 Z" fill="none" stroke="${OUTLINE}" stroke-width="1.4" stroke-linejoin="round"/>`,
+<path d="${BALL_PATH}" fill="none" stroke="${OUTLINE}" stroke-width="${OUTLINE_WIDTH}" stroke-linejoin="round"/>`,
 };
 
 /** 씰 아래쪽 반원 = 그릇, 위쪽 반원 = 뚜껑. 둘 다 같은 원 위에 있다. */
-const BOWL_PATH = `M ${SEAM_RIGHT} A 17 17 0 0 1 ${SEAM_LEFT} Z`;
-const LID_PATH = `M ${SEAM_LEFT} A 17 17 0 1 1 ${SEAM_RIGHT} Z`;
+const BOWL_PATH = `M ${SEAM_RIGHT} A ${RADIUS} ${RADIUS} 0 0 1 ${SEAM_LEFT} Z`;
+const LID_PATH = `M ${SEAM_LEFT} A ${RADIUS} ${RADIUS} 0 1 1 ${SEAM_RIGHT} Z`;
 
 const SELECTED: MarkerArt = {
-  // 폭은 닫힘 상태와 같다. 뚜껑을 45도 젖혀도 원래 폭을 넘지 않는다.
-  viewBox: { x: -0.4, y: -2.44, width: 40.8, height: 59.14 },
-  defs: `${SHADOW_GRADIENT}
-<clipPath id="b"><path d="${BOWL_PATH}"/></clipPath>
+  // 왼쪽 가장자리와 아래는 닫힘 상태와 맞춘다. 왼쪽을 맞춰야 두 상태의 anchorX가
+  // 같아져서 선택할 때 마커가 좌우로 흔들리지 않는다.
+  // 위와 오른쪽은 경첩 기준 45도 젖힌 뚜껑이 정한다. 원호를 촘촘히 훑어 구한
+  // 값이라 식으로 적을 수 없다. 여는 각도를 바꾸면 다시 재야 한다.
+  viewBox: {
+    x: CENTER_X - RADIUS - EDGE,
+    y: -2.44,
+    width: 38.09,
+    height: 48.14,
+  },
+  defs: `<clipPath id="b"><path d="${BOWL_PATH}"/></clipPath>
 <clipPath id="c"><path d="${LID_PATH}"/></clipPath>`,
-  body: `${SHADOW}
-<g clip-path="url(#b)">
+  body: `<g clip-path="url(#b)">
   <rect x="-40" y="-60" width="120" height="180" fill="${ORANGE}"/>
   ${SEAM_BAND}
 </g>
-<path d="${BOWL_PATH}" fill="none" stroke="${OUTLINE}" stroke-width="1.4" stroke-linejoin="round"/>
+<path d="${BOWL_PATH}" fill="none" stroke="${OUTLINE}" stroke-width="${OUTLINE_WIDTH}" stroke-linejoin="round"/>
 <g transform="rotate(45 ${SEAM_RIGHT})">
-  <path d="${LID_PATH}" fill="${GLASS}" stroke="${OUTLINE}" stroke-width="1.4" stroke-linejoin="round"/>
+  <path d="${LID_PATH}" fill="${GLASS}" stroke="${OUTLINE}" stroke-width="${OUTLINE_WIDTH}" stroke-linejoin="round"/>
   <g clip-path="url(#c)">${HIGHLIGHT}</g>
 </g>`,
 };
@@ -107,9 +116,18 @@ export interface MarkerIcon {
   /** 표시 크기 (CSS px) */
   width: number;
   height: number;
-  /** 이미지 좌상단 기준 기준점. 이 점이 좌표에 꽂힌다. */
+  /** 이미지 좌상단 기준 기준점. 캡슐의 중심이 좌표에 꽂힌다. */
   anchorX: number;
   anchorY: number;
+  /**
+   * 클릭과 마우스오버가 먹는 영역. 캡슐 원만 잡는다.
+   *
+   * 이걸 지정하지 않으면 이미지의 사각형 전체가 반응한다. 그러면 원 바깥
+   * 모서리에서도 클릭이 먹어서, 겹쳐 있는 다른 마커를 누르기 어려워진다.
+   * `shape`/`coords`는 HTML `<area>`와 같은 규칙이다.
+   */
+  hitShape: 'circle';
+  hitCoords: string;
 }
 
 function toDataUrl({ viewBox, defs, body }: MarkerArt) {
@@ -121,15 +139,23 @@ function toDataUrl({ viewBox, defs, body }: MarkerArt) {
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
+function round(value: number) {
+  return Math.round(value * 100) / 100;
+}
+
 function toIcon(art: MarkerArt): MarkerIcon {
   const { viewBox } = art;
+  const centerX = (CENTER_X - viewBox.x) * SCALE;
+  const centerY = (CENTER_Y - viewBox.y) * SCALE;
 
   return {
     src: toDataUrl(art),
     width: viewBox.width * SCALE,
     height: viewBox.height * SCALE,
-    anchorX: (CENTER_X - viewBox.x) * SCALE,
-    anchorY: (GROUND_Y - viewBox.y) * SCALE,
+    anchorX: centerX,
+    anchorY: centerY,
+    hitShape: 'circle',
+    hitCoords: `${round(centerX)},${round(centerY)},${round((RADIUS + EDGE) * SCALE)}`,
   };
 }
 

--- a/frontend/src/components/kakaoMap/revealPosition.ts
+++ b/frontend/src/components/kakaoMap/revealPosition.ts
@@ -1,0 +1,59 @@
+import type { LatLngLiteral } from './useKakaoMap';
+
+interface RevealOptions {
+  /** 화면 아래쪽이 무언가에 덮여 있는 높이 (px). 바텀시트 높이가 여기 들어온다. */
+  coveredHeight: number;
+  /** 가림막 윗변에서 이만큼 위에 좌표를 놓는다. 클수록 지도가 많이 움직인다. */
+  gap?: number;
+  /** 좌표가 화면 위 가장자리에 딱 붙지 않도록 남겨두는 여백 (px) */
+  margin?: number;
+}
+
+/**
+ * 가림막 윗변 바로 위에 붙인다. 남은 영역의 한가운데에 두면 지도가 필요 이상으로
+ * 많이 움직여서, 눌렀던 자리가 어디였는지 놓치기 쉽다.
+ *
+ * 32px 는 마커 아래 절반(12.5px)을 빼고도 20px 정도가 남는 값이다.
+ */
+const DEFAULT_GAP = 32;
+const DEFAULT_MARGIN = 24;
+
+/**
+ * 좌표가 화면 아래쪽 가림막에 덮여 있으면, 가림막 바로 위로 오도록 지도를 옮긴다.
+ *
+ * 이미 잘 보이는 위치면 아무것도 하지 않는다. 매번 옮기면 가려지지도 않은 마커까지
+ * 화면이 출렁여서 어지럽다.
+ */
+export function revealPosition(
+  map: kakao.maps.Map,
+  position: LatLngLiteral,
+  { coveredHeight, gap = DEFAULT_GAP, margin = DEFAULT_MARGIN }: RevealOptions,
+) {
+  const { maps } = window.kakao;
+  const height = map.getNode().clientHeight;
+  const visibleHeight = height - coveredHeight;
+
+  // 가림막이 화면을 거의 다 덮으면 어디로 옮겨도 소용없다.
+  if (visibleHeight < margin * 2) return;
+
+  const projection = map.getProjection();
+  const centerPoint = projection.pointFromCoords(map.getCenter());
+  const targetPoint = projection.pointFromCoords(
+    new maps.LatLng(position.lat, position.lng),
+  );
+
+  // 지도 컨테이너 기준으로 이 좌표가 지금 몇 px 높이에 있는지
+  const screenY = height / 2 + (targetPoint.y - centerPoint.y);
+
+  if (screenY >= margin && screenY <= visibleHeight - margin) return;
+
+  const targetY = Math.max(margin, visibleHeight - gap);
+
+  // 화면에서 위로 (screenY - 목표) 만큼 올리려면 중심을 같은 만큼 내린다.
+  const shift = screenY - targetY;
+  const nextCenter = projection.coordsFromPoint(
+    new maps.Point(centerPoint.x, centerPoint.y + shift),
+  );
+
+  map.panTo(nextCenter);
+}

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
@@ -1,6 +1,7 @@
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
+import { getBottomSheetTop } from '../model/bottomSheetState';
 import type { BottomSheetState } from '../model/storeDetail';
 
 const CONTENT_CARD_PADDING = '12px 16px';
@@ -37,20 +38,9 @@ interface SheetRootProps {
   $state: BottomSheetState;
 }
 
-function getSheetTop(state: BottomSheetState, dragOffset: number) {
-  const positions: Record<BottomSheetState, string> = {
-    closed: `calc(100% + ${dragOffset}px)`,
-    collapsed: `calc(100% - 116px + ${dragOffset}px)`,
-    summary: `calc(47% + ${dragOffset}px)`,
-    full: `calc(12px + ${dragOffset}px)`,
-  };
-
-  return positions[state];
-}
-
 export const SheetRoot = styled.section<SheetRootProps>`
   position: absolute;
-  top: ${({ $dragOffset, $state }) => getSheetTop($state, $dragOffset)};
+  top: ${({ $dragOffset, $state }) => getBottomSheetTop($state, $dragOffset)};
   right: 0;
   bottom: 0;
   left: 0;

--- a/frontend/src/features/storeDetail/hooks/useStoreDetailSheet.ts
+++ b/frontend/src/features/storeDetail/hooks/useStoreDetailSheet.ts
@@ -48,12 +48,16 @@ export function useStoreDetailSheet() {
    * 그냥 `openStoreDetail`을 다시 부르면 시트를 'closed'로 내렸다가 다음
    * 프레임에 'summary'로 올리기 때문에, 같은 곳을 눌렀는데 시트가 접혔다 펴지고
    * 상세 요청도 한 번 더 나간다.
+   *
+   * @returns 실제로 열었으면 true. 지도를 옮길지 판단하는 데 쓴다.
    */
   const selectStoreDetail = useCallback(
     (nextSelection: StorePinSelection) => {
-      if (isStoreOpen(nextSelection.storeId)) return;
+      if (isStoreOpen(nextSelection.storeId)) return false;
 
       openStoreDetail(nextSelection);
+
+      return true;
     },
     [isStoreOpen, openStoreDetail],
   );

--- a/frontend/src/features/storeDetail/index.ts
+++ b/frontend/src/features/storeDetail/index.ts
@@ -1,5 +1,6 @@
 export { default as StoreDetailSheet } from './components/StoreDetailSheet';
 export { default as StoreDetailSheetContainer } from './components/StoreDetailSheetContainer';
+export { getBottomSheetCoveredHeight } from './model/bottomSheetState';
 export { useStoreDetailSheet } from './hooks/useStoreDetailSheet';
 export type { StoreDetailSheetProps } from './components/StoreDetailSheet';
 export type { StorePinSelection } from './hooks/useStoreDetailSheet';

--- a/frontend/src/features/storeDetail/model/bottomSheetState.ts
+++ b/frontend/src/features/storeDetail/model/bottomSheetState.ts
@@ -8,6 +8,39 @@ const expandedStates: VisibleBottomSheetState[] = [
   'full',
 ];
 
+/**
+ * 각 단계에서 시트의 윗변이 놓이는 위치. 부모(지도 영역) 높이 기준이다.
+ *
+ * 스타일과 지도 이동 계산이 같은 값을 봐야 해서 한 곳에 둔다. 스타일에만 두면
+ * 디자인이 바뀔 때 지도가 조용히 어긋난다.
+ */
+const sheetTop: Record<BottomSheetState, { percent: number; px: number }> = {
+  closed: { percent: 100, px: 0 },
+  collapsed: { percent: 100, px: -116 },
+  summary: { percent: 47, px: 0 },
+  full: { percent: 0, px: 12 },
+};
+
+/** 시트의 `top`에 넣을 CSS 값. 드래그 중이면 그만큼 따라 움직인다. */
+export function getBottomSheetTop(state: BottomSheetState, dragOffset = 0) {
+  const { percent, px } = sheetTop[state];
+  const offset = px + dragOffset;
+  const sign = offset < 0 ? '-' : '+';
+
+  return `calc(${percent}% ${sign} ${Math.abs(offset)}px)`;
+}
+
+/** 시트가 화면 아래쪽을 덮는 높이(px). 지도를 얼마나 밀지 계산할 때 쓴다. */
+export function getBottomSheetCoveredHeight(
+  state: BottomSheetState,
+  containerHeight: number,
+) {
+  const { percent, px } = sheetTop[state];
+  const top = (containerHeight * percent) / 100 + px;
+
+  return Math.max(0, containerHeight - top);
+}
+
 export function getExpandedBottomSheetState(state: BottomSheetState) {
   if (state === 'closed' || state === 'full') return state;
 

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -1,10 +1,14 @@
+import { useCallback, useRef } from 'react';
 import styled from '@emotion/styled';
 
 import type { NearbyStoresFailure } from '@/apis/store';
 import ErrorNotice from '@/components/ErrorNotice';
 import KakaoMap from '@/components/kakaoMap/KakaoMap';
+import { revealPosition } from '@/components/kakaoMap/revealPosition';
 import StoreMarker from '@/components/kakaoMap/StoreMarker';
+import type { LatLngLiteral } from '@/components/kakaoMap/useKakaoMap';
 import {
+  getBottomSheetCoveredHeight,
   StoreDetailSheetContainer,
   useStoreDetailSheet,
 } from '@/features/storeDetail';
@@ -32,24 +36,51 @@ export default function MapPage() {
     state,
   } = useStoreDetailSheet();
 
+  const mapRef = useRef<kakao.maps.Map | null>(null);
+
   const stores = nearbyStores.status === 'success' ? nearbyStores.data : [];
+
+  /** 마커를 눌러 시트가 열릴 때, 그 마커가 시트에 가리면 지도를 옮겨준다. */
+  const handleMarkerClick = useCallback(
+    (storeId: number, position: LatLngLiteral, distanceMeters: number) => {
+      const opened = selectStoreDetail({ storeId, distanceMeters });
+      const map = mapRef.current;
+
+      if (!opened || !map) return;
+
+      revealPosition(map, position, {
+        coveredHeight: getBottomSheetCoveredHeight(
+          'summary',
+          map.getNode().clientHeight,
+        ),
+      });
+    },
+    [selectStoreDetail],
+  );
 
   return (
     <PageLayout>
-      <KakaoMap defaultCenter={DEFAULT_CENTER} onMapClick={collapseStoreDetail}>
-        {stores.map((store) => (
-          <StoreMarker
-            key={store.storeId}
-            position={{ lat: store.latitude, lng: store.longitude }}
-            isSelected={isStoreOpen(store.storeId)}
-            onClick={() =>
-              selectStoreDetail({
-                storeId: store.storeId,
-                distanceMeters: store.distance,
-              })
-            }
-          />
-        ))}
+      <KakaoMap
+        defaultCenter={DEFAULT_CENTER}
+        onMapClick={collapseStoreDetail}
+        onMapReady={(map) => {
+          mapRef.current = map;
+        }}
+      >
+        {stores.map((store) => {
+          const position = { lat: store.latitude, lng: store.longitude };
+
+          return (
+            <StoreMarker
+              key={store.storeId}
+              position={position}
+              isSelected={isStoreOpen(store.storeId)}
+              onClick={() =>
+                handleMarkerClick(store.storeId, position, store.distance)
+              }
+            />
+          );
+        })}
       </KakaoMap>
 
       {nearbyStores.status === 'loading' && (


### PR DESCRIPTION
## 작업 내용

<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->

1. 마커가 작아지고 그림자가 사라져서 겹침이 줄었다. 클릭 영역도 캡슐 원 안쪽으로만 좁혔다
2. 마커를 클릭하면 상세페이지에 가리지 않도록 지도가 마커를 시트 바로 위로 옮긴다

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #49 

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->

<img width="428" height="816" alt="image" src="https://github.com/user-attachments/assets/f6f05ac8-fb5e-43af-934d-3bc15a1aa6f2" />


## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->

현재 gap을 상세페이지를 기준으로 주었는데 이건이 맞는 판단인지 아니면 중간으로 마커를 옮기는 것이 좋은지 고민이다.

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [x] 포매터·린터를 통과했다
- [x] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다
