### PR TITLE
[FEAT] 매장별 가챠 섬네일 API 연동

### DIFF
--- a/frontend/src/features/storeDetail/api/getStoreGachaImageUrls.ts
+++ b/frontend/src/features/storeDetail/api/getStoreGachaImageUrls.ts
@@ -1,0 +1,96 @@
+import { SUCCESS_CODE } from '@/apis/store';
+
+import type { StoreGachaPageDto, StoreGachaSummaryDto } from './storeGacha.dto';
+
+interface GetStoreGachaImageUrlsOptions {
+  signal?: AbortSignal;
+}
+
+const PAGE_SIZE = 100;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function toStoreGachaSummary(value: unknown): StoreGachaSummaryDto | null {
+  if (!isRecord(value) || typeof value.gachaId !== 'number') return null;
+
+  const { thumbnailUrl } = value;
+
+  if (thumbnailUrl !== null && typeof thumbnailUrl !== 'string') return null;
+
+  return {
+    gachaId: value.gachaId,
+    thumbnailUrl,
+  };
+}
+
+function toStoreGachaPage(body: unknown): StoreGachaPageDto {
+  if (!isRecord(body) || body.code !== SUCCESS_CODE || !isRecord(body.data)) {
+    throw new Error('store-gachas/invalid-response');
+  }
+
+  const { content, number, totalPages } = body.data;
+
+  if (
+    !Array.isArray(content) ||
+    typeof number !== 'number' ||
+    typeof totalPages !== 'number'
+  ) {
+    throw new Error('store-gachas/invalid-page');
+  }
+
+  return {
+    content: content
+      .map(toStoreGachaSummary)
+      .filter((gacha): gacha is StoreGachaSummaryDto => gacha !== null),
+    number,
+    totalPages,
+  };
+}
+
+async function getStoreGachaPage(
+  storeId: number,
+  page: number,
+  options: GetStoreGachaImageUrlsOptions,
+) {
+  const query = new URLSearchParams({
+    page: String(page),
+    size: String(PAGE_SIZE),
+  });
+  const requestOptions: RequestInit = options.signal
+    ? { signal: options.signal }
+    : {};
+  const response = await fetch(
+    `/api/v1/stores/${storeId}/gachas?${query}`,
+    requestOptions,
+  );
+
+  if (!response.ok) {
+    throw new Error(`store-gachas/http-${response.status}`);
+  }
+
+  return toStoreGachaPage(await response.json());
+}
+
+export async function getStoreGachaImageUrls(
+  storeId: number,
+  options: GetStoreGachaImageUrlsOptions = {},
+) {
+  const firstPage = await getStoreGachaPage(storeId, 0, options);
+  const pages = [firstPage];
+
+  for (let page = 1; page < firstPage.totalPages; page += 1) {
+    pages.push(await getStoreGachaPage(storeId, page, options));
+  }
+
+  const imageUrls = pages.flatMap(({ content }) =>
+    content.flatMap(({ thumbnailUrl }) => {
+      const normalizedUrl = thumbnailUrl?.trim();
+
+      return normalizedUrl ? [normalizedUrl] : [];
+    }),
+  );
+
+  return Array.from(new Set(imageUrls));
+}

--- a/frontend/src/features/storeDetail/api/storeGacha.dto.ts
+++ b/frontend/src/features/storeDetail/api/storeGacha.dto.ts
@@ -1,0 +1,10 @@
+export interface StoreGachaSummaryDto {
+  gachaId: number;
+  thumbnailUrl: string | null;
+}
+
+export interface StoreGachaPageDto {
+  content: StoreGachaSummaryDto[];
+  number: number;
+  totalPages: number;
+}

--- a/frontend/src/features/storeDetail/components/StoreDetailSheetContainer.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheetContainer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import StoreDetailSheet from './StoreDetailSheet';
 import { getStoreDetail } from '../api/getStoreDetail';
+import { getStoreGachaImageUrls } from '../api/getStoreGachaImageUrls';
 import type { BottomSheetState, StoreDetail } from '../model/storeDetail';
 import { toStoreDetail } from '../model/toStoreDetail';
 
@@ -43,12 +44,23 @@ export default function StoreDetailSheetContainer({
 
     setRequestState({ status: 'loading' });
 
-    getStoreDetail(storeId, { signal: controller.signal })
-      .then((dto) => {
+    const gachaImageUrlsPromise = getStoreGachaImageUrls(storeId, {
+      signal: controller.signal,
+    }).catch((error: unknown) => {
+      if (isAbortError(error)) throw error;
+
+      return [];
+    });
+
+    Promise.all([
+      getStoreDetail(storeId, { signal: controller.signal }),
+      gachaImageUrlsPromise,
+    ])
+      .then(([dto, gachaImageUrls]) => {
         const store =
           distanceMeters === undefined
-            ? toStoreDetail(dto)
-            : toStoreDetail(dto, { distanceMeters });
+            ? toStoreDetail(dto, { gachaImageUrls })
+            : toStoreDetail(dto, { distanceMeters, gachaImageUrls });
 
         setRequestState({ status: 'success', store });
       })

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -7,7 +7,9 @@ import {
   type NearbyStore,
   type NearbyStoresData,
 } from '@/apis/store';
+import defaultStoreThumbnail from '@/assets/defaultStoreThumbnail.png';
 import type { StoreDetailDto } from '@/features/storeDetail/api/storeDetail.dto';
+import type { StoreGachaPageDto } from '@/features/storeDetail/api/storeGacha.dto';
 import { mockStoreDetail } from '@/features/storeDetail/mocks/storeDetail.mock';
 
 export const mockNearbyStores: NearbyStore[] = [
@@ -85,6 +87,27 @@ export const handlers = [
       code: SUCCESS_CODE,
       message: '요청이 성공했습니다.',
       data: storeDetail,
+    });
+  }),
+  http.get('/api/v1/stores/:storeId/gachas', ({ request }) => {
+    const params = new URL(request.url).searchParams;
+    const page = Number(params.get('page') ?? 0);
+    const size = Number(params.get('size') ?? 20);
+
+    return HttpResponse.json<ApiResponse<StoreGachaPageDto>>({
+      code: SUCCESS_CODE,
+      message: '요청이 성공했습니다.',
+      data: {
+        content:
+          page === 0
+            ? Array.from({ length: 8 }, (_, index) => ({
+                gachaId: index + 1,
+                thumbnailUrl: `${defaultStoreThumbnail}?gacha=${index + 1}`,
+              }))
+            : [],
+        number: page,
+        totalPages: size > 0 ? 1 : 0,
+      },
     });
   }),
 ];


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->

- 매장별 가챠 목록 조회 API(`/api/v1/stores/{storeId}/gachas`) 연동
- 페이지네이션된 가챠 목록을 전체 조회하여 `thumbnailUrl` 추출
- `null`, 빈 문자열 및 중복된 섬네일 URL 제거
- 조회한 섬네일을 매장 상세 가챠 이미지 갤러리에 전달
- 가챠 목록 API 요청이 실패해도 기존 매장 상세 정보는 정상적으로 표시되도록 처리
- Storybook에서 실제 API 연동 흐름을 확인할 수 있도록 MSW 목 응답 추가

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #39 

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->

## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->
- 한 매장에 가챠가 100개를 초과하는 경우에도 전체 페이지를 순차적으로 조회하도록 구현
- 가챠 목록 조회 실패가 매장 상세 전체의 오류로 이어지지 않도록 빈 이미지 목록으로 대체
- 유효하지 않은 항목은 제외하고 `null`, 빈 문자열 및 중복 URL을 렌더링 전에 정리하도록 처리

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [x] 포매터·린터를 통과했다
- [x] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다