### PR TITLE
[FEAT] 가챠 목록 미제공 매장 관심 요청 기능 추가

### DIFF
--- a/frontend/src/features/storeDetail/analytics/gachaCatalogInterestAnalytics.ts
+++ b/frontend/src/features/storeDetail/analytics/gachaCatalogInterestAnalytics.ts
@@ -1,0 +1,52 @@
+const GACHA_CATALOG_INTEREST_VIEWED = 'gacha_catalog_interest_viewed';
+const GACHA_CATALOG_INTEREST_CLICKED = 'gacha_catalog_interest_clicked';
+
+function getEnvironment() {
+  return window.location.hostname === 'gachigacha.kro.kr'
+    ? 'production'
+    : 'development';
+}
+
+function captureGachaCatalogInterest(
+  eventName:
+    | typeof GACHA_CATALOG_INTEREST_VIEWED
+    | typeof GACHA_CATALOG_INTEREST_CLICKED,
+  storeId: number,
+  storeName: string,
+  properties: Record<string, unknown> = {},
+) {
+  window.posthog?.capture(eventName, {
+    eligibility_reason: 'missing_instagram_and_gacha_images',
+    environment: getEnvironment(),
+    source: 'store_detail_gacha_tab',
+    store_id: storeId,
+    store_name: storeName,
+    ...properties,
+  });
+}
+
+export function captureGachaCatalogInterestViewed(
+  storeId: number,
+  storeName: string,
+  alreadyInterested: boolean,
+) {
+  captureGachaCatalogInterest(
+    GACHA_CATALOG_INTEREST_VIEWED,
+    storeId,
+    storeName,
+    {
+      already_interested: alreadyInterested,
+    },
+  );
+}
+
+export function captureGachaCatalogInterestClicked(
+  storeId: number,
+  storeName: string,
+) {
+  captureGachaCatalogInterest(
+    GACHA_CATALOG_INTEREST_CLICKED,
+    storeId,
+    storeName,
+  );
+}

--- a/frontend/src/features/storeDetail/components/GachaCatalogInterest.tsx
+++ b/frontend/src/features/storeDetail/components/GachaCatalogInterest.tsx
@@ -1,0 +1,45 @@
+import * as S from './StoreDetailSheet.styles';
+import { useGachaCatalogInterest } from '../hooks/useGachaCatalogInterest';
+import type { BottomSheetState } from '../model/storeDetail';
+
+interface GachaCatalogInterestProps {
+  state: BottomSheetState;
+  storeId: number;
+  storeName: string;
+}
+
+export default function GachaCatalogInterest({
+  state,
+  storeId,
+  storeName,
+}: GachaCatalogInterestProps) {
+  const { isInterested, requestInterest } = useGachaCatalogInterest(
+    storeId,
+    storeName,
+  );
+
+  return (
+    <S.GachaInterestCard $state={state}>
+      <S.GachaInterestMark aria-hidden="true">♡</S.GachaInterestMark>
+      <S.GachaInterestCopy aria-live="polite">
+        <S.GachaInterestTitle>
+          {isInterested ? '관심 요청이 기록됐어요' : '아직 가챠 목록이 없어요'}
+        </S.GachaInterestTitle>
+        <S.GachaInterestDescription>
+          {isInterested
+            ? '목록 제공 우선순위를 정하는 데 소중히 활용할게요.'
+            : '목록이 필요하다면 요청을 남겨주세요!'}
+        </S.GachaInterestDescription>
+      </S.GachaInterestCopy>
+      <S.GachaInterestButton
+        aria-label={`${storeName} 가챠 목록 ${isInterested ? '요청 완료' : '요청하기'}`}
+        aria-pressed={isInterested}
+        disabled={isInterested}
+        type="button"
+        onClick={requestInterest}
+      >
+        {isInterested ? '요청했어요' : '가챠 목록 요청하기'}
+      </S.GachaInterestButton>
+    </S.GachaInterestCard>
+  );
+}

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.stories.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.stories.tsx
@@ -10,6 +10,18 @@ import { mockStoreDetail } from '../mocks/storeDetail.mock';
 import { toStoreDetail } from '../model/toStoreDetail';
 
 const store = toStoreDetail(mockStoreDetail, { distanceMeters: 380 });
+const storeWithoutGachaSource = toStoreDetail(
+  {
+    ...mockStoreDetail,
+    instagramId: null,
+    storeId: 55,
+  },
+  {
+    distanceMeters: 380,
+    gachaImageUrls: [],
+    isGachaCatalogLoaded: true,
+  },
+);
 const storeWithGallery = toStoreDetail(
   {
     ...mockStoreDetail,
@@ -24,6 +36,7 @@ const storeWithGallery = toStoreDetail(
       { length: 8 },
       (_, index) => `${defaultStoreThumbnail}?gacha=${index + 1}`,
     ),
+    isGachaCatalogLoaded: true,
   },
 );
 const doNothing = () => undefined;
@@ -101,6 +114,18 @@ export const GalleryWithGachaImages: Story = {
       state="full"
       status="success"
       store={storeWithGallery}
+      onClose={doNothing}
+      onStateChange={doNothing}
+    />
+  ),
+};
+
+export const GachaInterestFakeDoor: Story = {
+  render: () => (
+    <StoreDetailSheet
+      state="full"
+      status="success"
+      store={storeWithoutGachaSource}
       onClose={doNothing}
       onStateChange={doNothing}
     />

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
@@ -533,6 +533,98 @@ export const ThumbnailPlaceholderMark = styled.div`
   }
 `;
 
+export const GachaInterestCard = styled.div<{ $state: BottomSheetState }>`
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  gap: 11px 13px;
+  align-items: center;
+  min-height: ${({ $state }) => ($state === 'summary' ? '142px' : '154px')};
+  padding: ${({ $state }) => ($state === 'summary' ? '14px' : '17px')};
+  margin-top: ${({ $state }) => ($state === 'summary' ? '10px' : '15px')};
+  background:
+    radial-gradient(
+      circle at 92% 18%,
+      rgb(255 255 255 / 78%) 0 12%,
+      transparent 13%
+    ),
+    linear-gradient(140deg, #fff6f8, #fbe9f0 55%, #f8eee8);
+  border: 1px solid #f0dfe5;
+  border-radius: 17px;
+`;
+
+export const GachaInterestMark = styled.span`
+  display: grid;
+  width: 48px;
+  height: 48px;
+  color: #a64268;
+  font-size: 30px;
+  line-height: 1;
+  background: rgb(255 255 255 / 86%);
+  border: 1px solid #f0d7e1;
+  border-radius: 50%;
+  box-shadow: 0 7px 18px rgb(134 64 89 / 10%);
+  place-items: center;
+`;
+
+export const GachaInterestCopy = styled.div`
+  min-width: 0;
+`;
+
+export const GachaInterestTitle = styled.strong`
+  display: block;
+  margin-bottom: 4px;
+  color: #4a343c;
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 1.4;
+  letter-spacing: -0.02em;
+`;
+
+export const GachaInterestDescription = styled.p`
+  margin: 0;
+  color: #7f6971;
+  font-size: 12px;
+  font-weight: 550;
+  line-height: 1.45;
+`;
+
+export const GachaInterestButton = styled.button`
+  grid-column: 1 / -1;
+  min-height: 39px;
+  padding: 9px 14px;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 800;
+  cursor: pointer;
+  background: #a94169;
+  border: 1px solid #a94169;
+  border-radius: 11px;
+  box-shadow: 0 5px 12px rgb(140 52 85 / 16%);
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    transform 140ms ease;
+
+  &:hover:not(:disabled) {
+    background: #923657;
+    border-color: #923657;
+    transform: translateY(-1px);
+  }
+
+  &:disabled {
+    color: #765e67;
+    cursor: default;
+    background: rgb(255 255 255 / 74%);
+    border-color: #e6ced7;
+    box-shadow: none;
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgb(180 73 113 / 28%);
+    outline-offset: 2px;
+  }
+`;
+
 export const InfoList = styled.dl`
   display: grid;
   gap: 10px;

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
@@ -16,8 +16,10 @@ import kujiIcon from '@/assets/kuji_icon.svg';
 import paymentsIcon from '@/assets/payments_icon.svg';
 import snsIcon from '@/assets/sns_icon.svg';
 
+import GachaCatalogInterest from './GachaCatalogInterest';
 import * as S from './StoreDetailSheet.styles';
 import { useBottomSheetDrag } from '../hooks/useBottomSheetDrag';
+import { isGachaCatalogInterestEligible } from '../model/isGachaCatalogInterestEligible';
 import type {
   BottomSheetState,
   StoreDetail,
@@ -109,8 +111,10 @@ function GalleryThumbnail({
 }
 
 interface StoreGalleryProps {
+  canRequestGachaCatalog: boolean;
   gachaImageUrls: string[];
   state: BottomSheetState;
+  storeId: number;
   storeImageUrls: string[];
   storeName: string;
 }
@@ -129,8 +133,10 @@ function getFrameScrollLeft(frame: HTMLElement, rail: HTMLElement) {
 }
 
 function StoreGallery({
+  canRequestGachaCatalog,
   gachaImageUrls,
   state,
+  storeId,
   storeImageUrls,
   storeName,
 }: StoreGalleryProps) {
@@ -139,6 +145,7 @@ function StoreGallery({
   const [showAll, setShowAll] = useState(false);
   const imageUrls = galleryKind === 'store' ? storeImageUrls : gachaImageUrls;
   const galleryConfig = GALLERY_CONFIG[galleryKind];
+  const showGachaInterest = galleryKind === 'gacha' && canRequestGachaCatalog;
   const thumbnails = imageUrls.length > 0 ? imageUrls : FALLBACK_THUMBNAILS;
   const railRef = useRef<HTMLDivElement>(null);
   const dragStartRef = useRef<GalleryDragStart | null>(null);
@@ -299,42 +306,51 @@ function StoreGallery({
             </S.GalleryTab>
           ))}
         </S.GalleryTabs>
-        <S.GalleryControls
-          aria-label={`${galleryConfig.label} 보기`}
-          role="group"
-        >
-          {state === 'full' && (
-            <S.GalleryViewButton
-              disabled={imageUrls.length === 0}
-              type="button"
-              onClick={() => setShowAll((isShowingAll) => !isShowingAll)}
-            >
-              {showAll ? '미리보기' : '더보기'}
-            </S.GalleryViewButton>
-          )}
-          {!showAll && (
-            <>
-              <S.GalleryControl
-                aria-label={`이전 ${galleryConfig.imageLabel}`}
-                disabled={!canSlideLeft}
+        {!showGachaInterest && (
+          <S.GalleryControls
+            aria-label={`${galleryConfig.label} 보기`}
+            role="group"
+          >
+            {state === 'full' && (
+              <S.GalleryViewButton
+                disabled={imageUrls.length === 0}
                 type="button"
-                onClick={() => slide(-1)}
+                onClick={() => setShowAll((isShowingAll) => !isShowingAll)}
               >
-                ‹
-              </S.GalleryControl>
-              <S.GalleryControl
-                aria-label={`다음 ${galleryConfig.imageLabel}`}
-                disabled={!canSlideRight}
-                type="button"
-                onClick={() => slide(1)}
-              >
-                ›
-              </S.GalleryControl>
-            </>
-          )}
-        </S.GalleryControls>
+                {showAll ? '미리보기' : '더보기'}
+              </S.GalleryViewButton>
+            )}
+            {!showAll && (
+              <>
+                <S.GalleryControl
+                  aria-label={`이전 ${galleryConfig.imageLabel}`}
+                  disabled={!canSlideLeft}
+                  type="button"
+                  onClick={() => slide(-1)}
+                >
+                  ‹
+                </S.GalleryControl>
+                <S.GalleryControl
+                  aria-label={`다음 ${galleryConfig.imageLabel}`}
+                  disabled={!canSlideRight}
+                  type="button"
+                  onClick={() => slide(1)}
+                >
+                  ›
+                </S.GalleryControl>
+              </>
+            )}
+          </S.GalleryControls>
+        )}
       </S.PhotoTitleRow>
-      {showAll ? (
+      {showGachaInterest ? (
+        <GachaCatalogInterest
+          key={storeId}
+          state={state}
+          storeId={storeId}
+          storeName={storeName}
+        />
+      ) : showAll ? (
         <S.PhotoGrid
           id={tabPanelId}
           aria-label={`${galleryConfig.label} 전체 보기`}
@@ -540,8 +556,10 @@ function StoreDetailContent({
         )}
 
         <StoreGallery
+          canRequestGachaCatalog={isGachaCatalogInterestEligible(store)}
           gachaImageUrls={store.gachaImageUrls}
           state={state}
+          storeId={store.id}
           storeImageUrls={store.imageUrls}
           storeName={store.name}
         />

--- a/frontend/src/features/storeDetail/components/StoreDetailSheetContainer.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheetContainer.tsx
@@ -46,21 +46,27 @@ export default function StoreDetailSheetContainer({
 
     const gachaImageUrlsPromise = getStoreGachaImageUrls(storeId, {
       signal: controller.signal,
-    }).catch((error: unknown) => {
-      if (isAbortError(error)) throw error;
+    })
+      .then((imageUrls) => ({ imageUrls, isLoaded: true }))
+      .catch((error: unknown) => {
+        if (isAbortError(error)) throw error;
 
-      return [];
-    });
+        return { imageUrls: [], isLoaded: false };
+      });
 
     Promise.all([
       getStoreDetail(storeId, { signal: controller.signal }),
       gachaImageUrlsPromise,
     ])
-      .then(([dto, gachaImageUrls]) => {
+      .then(([dto, gachaCatalog]) => {
+        const options = {
+          gachaImageUrls: gachaCatalog.imageUrls,
+          isGachaCatalogLoaded: gachaCatalog.isLoaded,
+        };
         const store =
           distanceMeters === undefined
-            ? toStoreDetail(dto, { gachaImageUrls })
-            : toStoreDetail(dto, { distanceMeters, gachaImageUrls });
+            ? toStoreDetail(dto, options)
+            : toStoreDetail(dto, { ...options, distanceMeters });
 
         setRequestState({ status: 'success', store });
       })

--- a/frontend/src/features/storeDetail/hooks/useGachaCatalogInterest.ts
+++ b/frontend/src/features/storeDetail/hooks/useGachaCatalogInterest.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  captureGachaCatalogInterestClicked,
+  captureGachaCatalogInterestViewed,
+} from '../analytics/gachaCatalogInterestAnalytics';
+
+const INTEREST_STORAGE_PREFIX = 'gacha-catalog-interest';
+const IMPRESSION_STORAGE_PREFIX = 'gacha-catalog-interest-impression';
+const capturedImpressionStoreIds = new Set<number>();
+
+function createStorageKey(prefix: string, storeId: number) {
+  return `${prefix}:${storeId}`;
+}
+
+function readInterest(storeId: number) {
+  try {
+    return (
+      window.localStorage.getItem(
+        createStorageKey(INTEREST_STORAGE_PREFIX, storeId),
+      ) === 'true'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function saveInterest(storeId: number) {
+  try {
+    window.localStorage.setItem(
+      createStorageKey(INTEREST_STORAGE_PREFIX, storeId),
+      'true',
+    );
+  } catch {
+    // 저장소 사용이 제한되어도 현재 화면의 요청 상태와 분석 이벤트는 유지한다.
+  }
+}
+
+function markImpression(storeId: number) {
+  if (capturedImpressionStoreIds.has(storeId)) return false;
+
+  const storageKey = createStorageKey(IMPRESSION_STORAGE_PREFIX, storeId);
+
+  try {
+    if (window.sessionStorage.getItem(storageKey) === 'true') return false;
+
+    window.sessionStorage.setItem(storageKey, 'true');
+  } catch {
+    // 세션 저장소가 제한된 환경에서는 메모리 기준으로 중복 노출을 방지한다.
+  }
+
+  capturedImpressionStoreIds.add(storeId);
+
+  return true;
+}
+
+export function useGachaCatalogInterest(storeId: number, storeName: string) {
+  const [isInterested, setIsInterested] = useState(() => readInterest(storeId));
+
+  useEffect(() => {
+    if (!markImpression(storeId)) return;
+
+    captureGachaCatalogInterestViewed(storeId, storeName, isInterested);
+  }, [isInterested, storeId, storeName]);
+
+  const requestInterest = useCallback(() => {
+    if (isInterested) return;
+
+    saveInterest(storeId);
+    setIsInterested(true);
+    captureGachaCatalogInterestClicked(storeId, storeName);
+  }, [isInterested, storeId, storeName]);
+
+  return { isInterested, requestInterest };
+}

--- a/frontend/src/features/storeDetail/model/isGachaCatalogInterestEligible.ts
+++ b/frontend/src/features/storeDetail/model/isGachaCatalogInterestEligible.ts
@@ -1,0 +1,18 @@
+import type { StoreDetail } from './storeDetail';
+
+export function isGachaCatalogInterestEligible(
+  store: Pick<
+    StoreDetail,
+    'gachaImageUrls' | 'isGachaCatalogLoaded' | 'socialLinks'
+  >,
+) {
+  const hasInstagram = store.socialLinks.some(
+    ({ platform }) => platform === 'instagram',
+  );
+
+  return (
+    store.isGachaCatalogLoaded &&
+    store.gachaImageUrls.length === 0 &&
+    !hasInstagram
+  );
+}

--- a/frontend/src/features/storeDetail/model/storeDetail.ts
+++ b/frontend/src/features/storeDetail/model/storeDetail.ts
@@ -17,6 +17,7 @@ export interface StoreDetail {
   businessHours: string;
   imageUrls: string[];
   gachaImageUrls: string[];
+  isGachaCatalogLoaded: boolean;
   phone: string | null;
   socialLinks: StoreDetailSocialLink[];
   categories: string[];

--- a/frontend/src/features/storeDetail/model/toStoreDetail.ts
+++ b/frontend/src/features/storeDetail/model/toStoreDetail.ts
@@ -8,6 +8,7 @@ import type { StoreDetailDto } from '../api/storeDetail.dto';
 interface ToStoreDetailOptions {
   distanceMeters?: number;
   gachaImageUrls?: string[];
+  isGachaCatalogLoaded?: boolean;
 }
 
 const AMOUNT_RANGES = [
@@ -166,6 +167,7 @@ export function toStoreDetail(
     businessHours: dto.businessHours ?? '정보 없음',
     imageUrls,
     gachaImageUrls: Array.from(new Set(options.gachaImageUrls ?? [])),
+    isGachaCatalogLoaded: options.isGachaCatalogLoaded === true,
     phone: dto.phoneNumber,
     socialLinks: instagram ? [instagram] : [],
     categories: createCategories(dto),

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -1,6 +1,14 @@
 declare const __IS_DEV__: boolean;
 declare const __KAKAO_MAP_KEY__: string;
 
+interface GachiPostHogClient {
+  capture(eventName: string, properties?: Record<string, unknown>): void;
+}
+
+interface Window {
+  posthog?: GachiPostHogClient;
+}
+
 declare module '*.png' {
   const src: string;
   export default src;


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->

- 가챠 목록 제공 상태에 따라 관심 요청 UI를 조건부로 표시
- 가챠 목록 미제공 매장에 안내 문구와 요청 버튼 추가

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #55 

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->
<img width="817" height="530" alt="image" src="https://github.com/user-attachments/assets/af9ee668-221e-458c-a2e9-a30a5b460efd" />

## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->
- 관심 요청 API가 실패해도 기존 매장 상세와 가챠 탭은 정상적으로 사용할 수 있도록 처리

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [x] 포매터·린터를 통과했다
- [x] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다
