### PR TITLE
[BUG] 매장 사진이 없어도 대표 사진 자리를 유지

### DIFF
--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
@@ -280,9 +280,9 @@ export const CompactMeta = styled.p`
 
 /* ------------------------------------------------------------------ 개요 */
 
-export const Content = styled.div<{ $hasHero: boolean }>`
+export const Content = styled.div`
   position: relative;
-  padding: ${({ $hasHero }) => ($hasHero ? space.md : '48px')} ${space.lg}
+  padding: ${space.md} ${space.lg}
     calc(${space.lg} + env(safe-area-inset-bottom));
   background: ${color.surface};
 `;

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
@@ -212,6 +212,18 @@ function useRailDrag(itemCount: number) {
 
 /* ---------------------------------------------------------- 대표 사진 */
 
+/** 도형은 지도 마커(`markerIcon.ts`)와 같은 원·씰 좌표를 쓴다. */
+function CapsuleMark() {
+  return (
+    <S.ThumbnailPlaceholderMark aria-hidden="true" viewBox="0 0 40 56">
+      <circle className="capsule-body" cx="20" cy="28" r="17" />
+      <g transform="rotate(-14 20 28)">
+        <rect className="capsule-seam" x="0" y="26" width="40" height="4" />
+      </g>
+    </S.ThumbnailPlaceholderMark>
+  );
+}
+
 interface StoreHeroProps {
   imageUrls: string[];
   storeName: string;
@@ -220,8 +232,8 @@ interface StoreHeroProps {
 /**
  * 시트 맨 위 대표 사진.
  *
- * 사진이 없으면 아무것도 그리지 않는다. 회색 자리 표시로 화면 위쪽
- * 200px 을 채우느니 이름부터 시작하는 편이 낫다.
+ * 사진이 없어도 자리를 비우지 않는다. 비우면 이름이 시작하는 높이가 225px 에서
+ * 48px 로 내려앉아, 매장을 옮겨가며 볼 때 같은 화면이 다르게 보인다.
  */
 function StoreHero({ imageUrls, storeName }: StoreHeroProps) {
   const [brokenUrls, setBrokenUrls] = useState<string[]>([]);
@@ -230,7 +242,19 @@ function StoreHero({ imageUrls, storeName }: StoreHeroProps) {
     usableUrls.length,
   );
 
-  if (usableUrls.length === 0) return null;
+  if (usableUrls.length === 0) {
+    return (
+      <S.Hero>
+        <S.ThumbnailPlaceholder
+          aria-label={`${storeName} 매장 사진 준비 중`}
+          role="img"
+        >
+          <CapsuleMark />
+          <span>매장 사진 준비 중</span>
+        </S.ThumbnailPlaceholder>
+      </S.Hero>
+    );
+  }
 
   return (
     <S.Hero>
@@ -272,18 +296,6 @@ interface GachaThumbnailProps {
   imageUrl: string | null;
   index: number;
   storeName: string;
-}
-
-/** 도형은 지도 마커(`markerIcon.ts`)와 같은 원·씰 좌표를 쓴다. */
-function CapsuleMark() {
-  return (
-    <S.ThumbnailPlaceholderMark aria-hidden="true" viewBox="0 0 40 56">
-      <circle className="capsule-body" cx="20" cy="28" r="17" />
-      <g transform="rotate(-14 20 28)">
-        <rect className="capsule-seam" x="0" y="26" width="40" height="4" />
-      </g>
-    </S.ThumbnailPlaceholderMark>
-  );
 }
 
 function GachaThumbnail({ imageUrl, index, storeName }: GachaThumbnailProps) {
@@ -605,7 +617,6 @@ function StoreDetailContent({
   titleId,
 }: StoreDetailContentProps) {
   const scrollAreaRef = useRef<HTMLDivElement>(null);
-  const hasHero = store.imageUrls.length > 0;
   // 첫 페이지 밖에 사진이 더 있을 때만 전체 보기로 데려갈 곳이 생긴다.
   const hasFullCatalog =
     state === 'full' &&
@@ -665,7 +676,7 @@ function StoreDetailContent({
 
         <StoreHero imageUrls={store.imageUrls} storeName={store.name} />
 
-        <S.Content $hasHero={hasHero}>
+        <S.Content>
           <S.Overview>
             <S.OverviewHeading>
               <S.StoreName id={titleId}>{store.name}</S.StoreName>


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->

사진이 없으면 히어로를 그리지 않아 매장 이름이 시작하는 높이가 `225px`에서 `48px`로
내려앉았습니다. 마커를 옮겨가며 누르면 같은 화면이 다르게 보였습니다.

- 사진이 없어도 대표 사진 자리를 유지하고 `매장 사진 준비 중`을 그립니다
- `Content`의 `$hasHero` 분기를 제거했습니다. 이제 패딩이 하나로 고정입니다

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #62 

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->

**Before**
<img width="430" height="782" alt="image" src="https://github.com/user-attachments/assets/8bdd59dd-5540-4c4a-a6e1-1530b3c5f69c" />

**After**

<img width="428" height="817" alt="image" src="https://github.com/user-attachments/assets/7ca3ed18-3550-435e-a5ed-25c9e16f30af" />


## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [x] 포매터·린터를 통과했다
- [x] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다
