### PR TITLE
[FEAT] 사진을 눌러 전체화면으로 보기

### DIFF
--- a/frontend/src/features/storeDetail/components/PhotoViewer.styles.ts
+++ b/frontend/src/features/storeDetail/components/PhotoViewer.styles.ts
@@ -1,0 +1,174 @@
+import styled from '@emotion/styled';
+
+import {
+  alpha,
+  color,
+  focusRing,
+  fontSize,
+  radius,
+  space,
+} from '@/styles/tokens';
+
+/**
+ * 뒤를 가리는 막.
+ *
+ * 흐림(`backdrop-filter`)은 쓰지 않는다. 흐림을 세게 주면 지도의 도로와 블록이
+ * 뭉개져 결국 균일한 어두운 면이 되고, 약하게 주면 저사양 기기에서 값을 치르고도
+ * 얻는 게 적다. 단색으로도 뒤 형태는 남는다.
+ */
+export const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: ${alpha(color.ink, 90)};
+`;
+
+/** 앱과 같은 폭 안에 둔다. 뷰어만 넓어지면 화면이 갑자기 커진 것처럼 보인다. */
+export const Frame = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 430px;
+  height: 100%;
+  margin: 0 auto;
+`;
+
+/**
+ * 상단바에 배경을 깔지 않는다. 전체에 그라데이션을 깔면 사진 위쪽이 어두워진다.
+ * 대신 버튼이 자기 배경을 갖는다.
+ */
+export const TopBar = styled.div`
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-end;
+  height: 58px;
+  padding: 0 ${space.md};
+`;
+
+export const CloseButton = styled.button`
+  display: grid;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  color: ${color.surface};
+  cursor: pointer;
+  background: ${alpha(color.surface, 16)};
+  border: 0;
+  border-radius: ${radius.circle};
+  place-items: center;
+
+  svg {
+    width: 19px;
+    height: 19px;
+    fill: none;
+    stroke: currentcolor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+  }
+
+  &:focus-visible {
+    outline: ${focusRing};
+    outline-offset: 2px;
+  }
+`;
+
+export const Rail = styled.div<{ $isDragging: boolean }>`
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  scroll-snap-type: ${({ $isDragging }) =>
+    $isDragging ? 'none' : 'x mandatory'};
+  touch-action: pan-y;
+  user-select: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const Slide = styled.div`
+  display: grid;
+  flex: 0 0 100%;
+  height: 100%;
+  padding: 0 ${space.md} ${space.sm};
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  place-items: center;
+`;
+
+/** 잘라내지 않는다. 크게 보려고 연 화면이라 사진 전체가 보여야 한다. */
+export const Photo = styled.img`
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  user-select: none;
+  object-fit: contain;
+  -webkit-user-drag: none;
+`;
+
+export const Counter = styled.p`
+  flex: 0 0 auto;
+  padding: 0 ${space.md} 10px;
+  margin: 0;
+  color: ${alpha(color.surface, 78)};
+  font-size: ${fontSize.sm};
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+`;
+
+export const Strip = styled.div`
+  display: flex;
+  flex: 0 0 auto;
+  gap: 7px;
+  padding: 0 ${space.md} calc(${space.lg} + env(safe-area-inset-bottom));
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const StripItem = styled.button<{ $isActive: boolean }>`
+  position: relative;
+  flex: 0 0 auto;
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  overflow: hidden;
+  cursor: pointer;
+  background: ${alpha(color.surface, 12)};
+  border: 0;
+  border-radius: ${radius.sm};
+
+  img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  /*
+   * 흰 테두리만으로는 안 보인다. 가챠 사진은 배경이 밝은 것이 많아 흰 선이
+   * 사진에 묻힌다. 고르지 않은 칸을 어둡게 덮어 고른 칸이 드러나게 한다.
+   */
+  &::after {
+    position: absolute;
+    inset: 0;
+    content: '';
+    background: ${({ $isActive }) =>
+      $isActive ? 'transparent' : alpha(color.ink, 58)};
+    border: 2px solid
+      ${({ $isActive }) => ($isActive ? color.surface : 'transparent')};
+    border-radius: ${radius.sm};
+  }
+
+  &:focus-visible {
+    outline: ${focusRing};
+    outline-offset: 2px;
+  }
+`;

--- a/frontend/src/features/storeDetail/components/PhotoViewer.tsx
+++ b/frontend/src/features/storeDetail/components/PhotoViewer.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState, type SyntheticEvent } from 'react';
+import { createPortal } from 'react-dom';
+
+import * as S from './PhotoViewer.styles';
+import { useBackClose } from '../hooks/useBackClose';
+import { useRailDrag } from '../hooks/useRailDrag';
+
+interface PhotoViewerProps {
+  imageUrls: string[];
+  /** 어느 장에서 열렸는지. 누른 사진이 먼저 보여야 한다. */
+  startIndex: number;
+  title: string;
+  onClose: () => void;
+}
+
+/**
+ * 사진을 화면 가득 보는 층.
+ *
+ * 시트 위가 아니라 문서 맨 위에 붙는다. `SheetRoot` 가 `overflow: hidden` 이라
+ * 그 안에서는 시트 밖으로 나갈 수 없다.
+ *
+ * 시트는 닫지 않는다. 뷰어를 닫으면 보던 자리로 그대로 돌아와야 한다.
+ */
+export default function PhotoViewer({
+  imageUrls,
+  startIndex,
+  title,
+  onClose,
+}: PhotoViewerProps) {
+  const { activeIndex, isDragging, railProps, railRef, scrollToIndex } =
+    useRailDrag(imageUrls.length);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
+  const hasScrolledStripRef = useRef(false);
+  const [hasStarted, setHasStarted] = useState(false);
+
+  // 닫는 길은 하나뿐이다. 버튼도 뒤로가기를 부르고 실제로 닫는 건 useBackClose 가 한다.
+  const requestClose = () => history.back();
+
+  useBackClose(true, onClose);
+
+  useEffect(() => {
+    // 열자마자 누른 장으로 보낸다. 애니메이션 없이 한 번에.
+    const rail = railRef.current;
+
+    if (!rail || hasStarted) return;
+
+    scrollToIndex(startIndex, 'auto');
+    setHasStarted(true);
+    closeButtonRef.current?.focus();
+  }, [hasStarted, railRef, scrollToIndex, startIndex]);
+
+  useEffect(() => {
+    // 사진을 넘기면 아래 줄도 따라온다. 30번째를 보는데 줄은 첫 장에 머물러
+    // 있으면 지금 어디쯤인지 줄에서 확인할 수가 없다.
+    //
+    // 보고 있는 장을 줄의 맨 왼쪽에 둔다. 그러면 오른쪽이 전부 앞으로 볼
+    // 사진이라 다음에 무엇이 오는지 한눈에 들어온다.
+    //
+    // scrollIntoView 는 조상까지 스크롤할 수 있어 직접 계산한다.
+    const strip = stripRef.current;
+    const item = strip?.children.item(activeIndex) as HTMLElement | null;
+    const firstItem = strip?.children.item(0) as HTMLElement | null;
+
+    if (!strip || !item || !firstItem) return;
+
+    // 첫 칸이 놓인 자리만큼 빼면 좌우 여백이 첫 장일 때와 같아진다.
+    const alignedToLeft = item.offsetLeft - firstItem.offsetLeft;
+    const isFirstRender = !hasScrolledStripRef.current;
+
+    hasScrolledStripRef.current = true;
+    strip.scrollTo({
+      behavior: isFirstRender ? 'auto' : 'smooth',
+      left: alignedToLeft,
+    });
+  }, [activeIndex]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') requestClose();
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    // 뷰어가 떠 있는 동안 뒤 화면이 따라 움직이면 어지럽다.
+    const { overflow } = document.body.style;
+
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = overflow;
+    };
+  }, []);
+
+  /**
+   * React 는 포털 안의 이벤트를 DOM 이 아니라 React 트리를 따라 올린다.
+   * 뷰어가 body 에 붙어 있어도 클릭과 포인터가 시트의 드래그 핸들러로 들어가,
+   * 아래 썸네일을 누르면 시트가 끌려 내려가 닫혀버린다.
+   */
+  const stopBubbling = (event: SyntheticEvent) => event.stopPropagation();
+
+  return createPortal(
+    <S.Backdrop
+      aria-label={title}
+      aria-modal="true"
+      role="dialog"
+      onClick={stopBubbling}
+      onPointerCancel={stopBubbling}
+      onPointerDown={stopBubbling}
+      onPointerMove={stopBubbling}
+      onPointerUp={stopBubbling}
+    >
+      <S.Frame>
+        <S.TopBar>
+          <S.CloseButton
+            ref={closeButtonRef}
+            aria-label="사진 닫기"
+            type="button"
+            onClick={requestClose}
+          >
+            <svg aria-hidden="true" viewBox="0 0 20 20">
+              <path d="M5 5 15 15M15 5 5 15" />
+            </svg>
+          </S.CloseButton>
+        </S.TopBar>
+
+        <S.Rail
+          ref={railRef}
+          $isDragging={isDragging}
+          aria-label={title}
+          data-horizontal-scroll
+          {...railProps}
+        >
+          {imageUrls.map((imageUrl, index) => (
+            <S.Slide key={imageUrl}>
+              <S.Photo
+                alt={`${title} ${index + 1}`}
+                draggable={false}
+                src={imageUrl}
+              />
+            </S.Slide>
+          ))}
+        </S.Rail>
+
+        {imageUrls.length > 1 && (
+          <>
+            <S.Counter aria-live="polite">
+              {activeIndex + 1} / {imageUrls.length}
+            </S.Counter>
+            <S.Strip ref={stripRef} aria-label={`${title} 목록`}>
+              {imageUrls.map((imageUrl, index) => (
+                <S.StripItem
+                  key={imageUrl}
+                  $isActive={index === activeIndex}
+                  aria-current={index === activeIndex}
+                  aria-label={`${index + 1}번째 사진 보기`}
+                  type="button"
+                  onClick={() => scrollToIndex(index)}
+                >
+                  <img alt="" src={imageUrl} />
+                </S.StripItem>
+              ))}
+            </S.Strip>
+          </>
+        )}
+      </S.Frame>
+    </S.Backdrop>,
+    document.body,
+  );
+}

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.stories.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.stories.tsx
@@ -171,6 +171,19 @@ export const Collapsed: Story = {
   ),
 };
 
+/** 사진을 눌러 전체화면으로 여는 흐름. 히어로와 가챠 사진 둘 다 열린다. */
+export const PhotoViewerFlow: Story = {
+  render: () => (
+    <StoreDetailSheet
+      state="full"
+      status="success"
+      store={storeWithGallery}
+      onClose={doNothing}
+      onStateChange={doNothing}
+    />
+  ),
+};
+
 export const Loading: Story = {
   render: () => (
     <StoreDetailSheet

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.styles.ts
@@ -525,12 +525,20 @@ export const PhotoGrid = styled.div`
   gap: ${space.xs};
 `;
 
-export const GridImageFrame = styled.div`
+/** 눌러서 크게 볼 수 있으므로 버튼이다. */
+export const GridImageFrame = styled.button`
+  padding: 0;
   overflow: hidden;
   aspect-ratio: 1;
+  cursor: pointer;
   background: ${color.surface2};
   border: 1px solid ${color.line};
   border-radius: ${radius.md};
+
+  &:focus-visible {
+    outline: ${focusRing};
+    outline-offset: 2px;
+  }
 `;
 
 export const ThumbnailImage = styled.img`

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useId,
   useRef,
@@ -15,6 +16,7 @@ import paymentsIcon from '@/assets/payments_icon.svg';
 import snsIcon from '@/assets/sns_icon.svg';
 
 import GachaCatalogInterest from './GachaCatalogInterest';
+import PhotoViewer from './PhotoViewer';
 import * as S from './StoreDetailSheet.styles';
 import { useBottomSheetDrag } from '../hooks/useBottomSheetDrag';
 import { useGachaCatalogPages } from '../hooks/useGachaCatalogPages';
@@ -76,6 +78,7 @@ function CapsuleMark() {
 interface StoreHeroProps {
   imageUrls: string[];
   storeName: string;
+  onOpenPhoto: (imageUrls: string[], index: number) => void;
 }
 
 /**
@@ -84,11 +87,12 @@ interface StoreHeroProps {
  * 사진이 없어도 자리를 비우지 않는다. 비우면 이름이 시작하는 높이가 225px 에서
  * 48px 로 내려앉아, 매장을 옮겨가며 볼 때 같은 화면이 다르게 보인다.
  */
-function StoreHero({ imageUrls, storeName }: StoreHeroProps) {
+function StoreHero({ imageUrls, storeName, onOpenPhoto }: StoreHeroProps) {
   const [brokenUrls, setBrokenUrls] = useState<string[]>([]);
   const usableUrls = imageUrls.filter((url) => !brokenUrls.includes(url));
   const { activeIndex, isDragging, railProps, railRef } = useRailDrag(
     usableUrls.length,
+    { onTapItem: (index) => onOpenPhoto(usableUrls, index) },
   );
 
   if (usableUrls.length === 0) {
@@ -179,6 +183,7 @@ interface GachaGalleryProps {
   storeName: string;
   /** 전체 보기를 누르면 맨 아래 전체 섹션으로 데려간다. 없으면 버튼을 안 그린다. */
   onShowAll: (() => void) | null;
+  onOpenPhoto: (imageUrls: string[], index: number) => void;
 }
 
 /**
@@ -193,13 +198,18 @@ function GachaGallery({
   storeId,
   storeName,
   onShowAll,
+  onOpenPhoto,
 }: GachaGalleryProps) {
   const titleId = useId();
   const thumbnails =
     imageUrls.length > 0
       ? imageUrls.slice(0, RAIL_PREVIEW_COUNT)
       : FALLBACK_THUMBNAILS;
-  const { isDragging, railProps, railRef } = useRailDrag(thumbnails.length);
+  const { isDragging, railProps, railRef } = useRailDrag(thumbnails.length, {
+    onTapItem: (index) => {
+      if (imageUrls.length > 0) onOpenPhoto(imageUrls, index);
+    },
+  });
 
   return (
     <S.GachaSection aria-labelledby={titleId}>
@@ -230,7 +240,7 @@ function GachaGallery({
               </S.ThumbnailFrame>
             ))}
             {onShowAll && (
-              <S.ShowAllSlot>
+              <S.ShowAllSlot data-rail-control>
                 <S.ShowAllButton
                   aria-label="가챠 사진 전체보기"
                   type="button"
@@ -255,6 +265,7 @@ interface GachaCatalogProps {
   storeId: number;
   storeName: string;
   totalPages: number;
+  onOpenPhoto: (imageUrls: string[], index: number) => void;
 }
 
 /**
@@ -268,6 +279,7 @@ function GachaCatalog({
   storeId,
   storeName,
   totalPages,
+  onOpenPhoto,
 }: GachaCatalogProps) {
   const titleId = useId();
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -301,7 +313,12 @@ function GachaCatalog({
       <S.SectionTitle id={titleId}>가챠 사진 전체</S.SectionTitle>
       <S.PhotoGrid>
         {imageUrls.map((imageUrl, index) => (
-          <S.GridImageFrame key={imageUrl}>
+          <S.GridImageFrame
+            key={imageUrl}
+            aria-label={`${storeName} 가챠 사진 ${index + 1} 크게 보기`}
+            type="button"
+            onClick={() => onOpenPhoto(imageUrls, index)}
+          >
             <GachaThumbnail
               imageUrl={imageUrl}
               index={index}
@@ -480,6 +497,15 @@ function StoreDetailContent({
 
   const topSentinelRef = useRef<HTMLDivElement>(null);
   const [isScrolledDown, setIsScrolledDown] = useState(false);
+  const [photoView, setPhotoView] = useState<{
+    imageUrls: string[];
+    startIndex: number;
+  } | null>(null);
+
+  const openPhoto = (imageUrls: string[], startIndex: number) =>
+    setPhotoView({ imageUrls, startIndex });
+
+  const closePhoto = useCallback(() => setPhotoView(null), []);
 
   useEffect(() => {
     const sentinel = topSentinelRef.current;
@@ -523,7 +549,11 @@ function StoreDetailContent({
       >
         <S.TopSentinel ref={topSentinelRef} aria-hidden="true" />
 
-        <StoreHero imageUrls={store.imageUrls} storeName={store.name} />
+        <StoreHero
+          imageUrls={store.imageUrls}
+          storeName={store.name}
+          onOpenPhoto={openPhoto}
+        />
 
         <S.Content>
           <S.Overview>
@@ -559,6 +589,7 @@ function StoreDetailContent({
             imageUrls={store.gachaImageUrls}
             storeId={store.id}
             storeName={store.name}
+            onOpenPhoto={openPhoto}
             onShowAll={hasFullCatalog ? showCatalog : null}
           />
 
@@ -648,12 +679,22 @@ function StoreDetailContent({
                   storeId={store.id}
                   storeName={store.name}
                   totalPages={store.gachaTotalPages}
+                  onOpenPhoto={openPhoto}
                 />
               )}
             </>
           )}
         </S.Content>
       </S.ScrollArea>
+
+      {photoView && (
+        <PhotoViewer
+          imageUrls={photoView.imageUrls}
+          startIndex={photoView.startIndex}
+          title={`${store.name} 사진`}
+          onClose={closePhoto}
+        />
+      )}
 
       {isScrolledDown && (
         <S.ScrollTopButton

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.tsx
@@ -1,10 +1,8 @@
 import {
-  useCallback,
   useEffect,
   useId,
   useRef,
   useState,
-  type PointerEvent as ReactPointerEvent,
   type ReactNode,
 } from 'react';
 
@@ -20,6 +18,7 @@ import GachaCatalogInterest from './GachaCatalogInterest';
 import * as S from './StoreDetailSheet.styles';
 import { useBottomSheetDrag } from '../hooks/useBottomSheetDrag';
 import { useGachaCatalogPages } from '../hooks/useGachaCatalogPages';
+import { useRailDrag } from '../hooks/useRailDrag';
 import { isGachaCatalogInterestEligible } from '../model/isGachaCatalogInterestEligible';
 import type {
   BottomSheetState,
@@ -59,156 +58,6 @@ const RAIL_PREVIEW_COUNT = 5;
 
 /** 전체 보기가 데려갈 자리. 시트 안에서만 쓰는 id 라 고정값이면 충분하다. */
 const GACHA_CATALOG_ID = 'gacha-catalog';
-
-/** 이만큼 끌어야 다음 장으로 넘어간다. 그보다 짧으면 제자리로 돌아온다. */
-const RAIL_SNAP_DISTANCE = 36;
-
-/* ------------------------------------------------------------ 가로 레일 */
-
-interface RailDragStart {
-  activeIndex: number;
-  pointerId: number;
-  scrollLeft: number;
-  x: number;
-}
-
-function getFrameScrollLeft(frame: HTMLElement, rail: HTMLElement) {
-  const firstFrame = rail.children.item(0) as HTMLElement | null;
-
-  return frame.offsetLeft - (firstFrame?.offsetLeft ?? 0);
-}
-
-/**
- * 손가락으로 끌어 넘기는 가로 목록.
- *
- * 시트 자체가 위아래 드래그를 가로채기 때문에 브라우저 기본 스크롤에만
- * 맡길 수 없다. 포인터를 직접 받아 어느 장에 멈출지 정한다.
- *
- * 대표 사진과 가챠 사진이 같은 동작을 해야 해서 한 곳에 둔다.
- */
-function useRailDrag(itemCount: number) {
-  const railRef = useRef<HTMLDivElement>(null);
-  const dragStartRef = useRef<RailDragStart | null>(null);
-  const dragDistanceRef = useRef(0);
-  const [activeIndex, setActiveIndex] = useState(0);
-  const [isDragging, setIsDragging] = useState(false);
-
-  const updateSlideControls = useCallback(() => {
-    const rail = railRef.current;
-
-    if (!rail) return;
-
-    const frames = Array.from(rail.children) as HTMLElement[];
-    const nextActiveIndex = frames.reduce((closestIndex, frame, index) => {
-      const closestFrame = frames[closestIndex];
-
-      if (!closestFrame) return index;
-
-      return Math.abs(getFrameScrollLeft(frame, rail) - rail.scrollLeft) <
-        Math.abs(getFrameScrollLeft(closestFrame, rail) - rail.scrollLeft)
-        ? index
-        : closestIndex;
-    }, 0);
-
-    setActiveIndex(nextActiveIndex);
-  }, []);
-
-  useEffect(() => {
-    const rail = railRef.current;
-
-    if (!rail) return;
-
-    updateSlideControls();
-
-    const resizeObserver = new ResizeObserver(updateSlideControls);
-
-    resizeObserver.observe(rail);
-
-    return () => resizeObserver.disconnect();
-  }, [itemCount, updateSlideControls]);
-
-  const scrollToIndex = useCallback(
-    (rail: HTMLElement, index: number) => {
-      const nextIndex = Math.min(Math.max(index, 0), itemCount - 1);
-      const nextFrame = rail.children.item(nextIndex) as HTMLElement | null;
-
-      if (!nextFrame) return;
-
-      rail.scrollTo({
-        behavior: 'smooth',
-        left: getFrameScrollLeft(nextFrame, rail),
-      });
-    },
-    [itemCount],
-  );
-
-  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.pointerType === 'mouse' && event.button !== 0) return;
-
-    // 레일이 포인터를 캡처하면 그 안의 버튼은 click 을 못 받는다.
-    // 눌린 곳이 버튼이면 끌기를 시작하지 않는다.
-    if ((event.target as HTMLElement).closest('button')) return;
-
-    dragStartRef.current = {
-      activeIndex,
-      pointerId: event.pointerId,
-      scrollLeft: event.currentTarget.scrollLeft,
-      x: event.clientX,
-    };
-    dragDistanceRef.current = 0;
-    setIsDragging(true);
-    event.currentTarget.setPointerCapture(event.pointerId);
-  };
-
-  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
-    const dragStart = dragStartRef.current;
-
-    if (!dragStart || dragStart.pointerId !== event.pointerId) return;
-
-    const dragDistance = event.clientX - dragStart.x;
-
-    dragDistanceRef.current = dragDistance;
-    event.currentTarget.scrollLeft = dragStart.scrollLeft - dragDistance;
-
-    if (Math.abs(dragDistance) > 4) event.preventDefault();
-  };
-
-  const finishDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
-    const dragStart = dragStartRef.current;
-
-    if (!dragStart || dragStart.pointerId !== event.pointerId) return;
-
-    const direction =
-      Math.abs(dragDistanceRef.current) < RAIL_SNAP_DISTANCE
-        ? 0
-        : dragDistanceRef.current > 0
-          ? -1
-          : 1;
-
-    scrollToIndex(event.currentTarget, dragStart.activeIndex + direction);
-
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-
-    dragStartRef.current = null;
-    dragDistanceRef.current = 0;
-    setIsDragging(false);
-  };
-
-  return {
-    activeIndex,
-    isDragging,
-    railProps: {
-      onPointerCancel: finishDrag,
-      onPointerDown: handlePointerDown,
-      onPointerMove: handlePointerMove,
-      onPointerUp: finishDrag,
-      onScroll: updateSlideControls,
-    },
-    railRef,
-  };
-}
 
 /* ---------------------------------------------------------- 대표 사진 */
 

--- a/frontend/src/features/storeDetail/hooks/useBackClose.ts
+++ b/frontend/src/features/storeDetail/hooks/useBackClose.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+
+/** 층이 열린 순서. 나중에 연 것이 큰 번호를 갖는다. */
+let layerSequence = 0;
+
+function getOpenLayerId() {
+  const { state } = history;
+
+  if (typeof state !== 'object' || state === null) return 0;
+
+  const { closableLayer } = state as { closableLayer?: unknown };
+
+  return typeof closableLayer === 'number' ? closableLayer : 0;
+}
+
+/**
+ * 휴대폰 뒤로가기로 닫는다.
+ *
+ * 웹이라 안드로이드 뒤로가기와 iOS 가장자리 스와이프가 그대로 들어온다.
+ * 아무것도 안 하면 사진을 보다가 뒤로가기를 눌렀을 때 앱을 나간다.
+ *
+ * 닫는 길은 하나뿐이어야 한다. 닫기 버튼도 상태를 직접 바꾸지 말고
+ * `history.back()` 을 부르고, 실제로 닫는 건 여기서만 한다. 버튼이 상태만
+ * 바꾸면 쌓아둔 항목이 남아서 다음 뒤로가기가 아무 일도 안 하고,
+ * 사용자 눈에는 한 번 씹힌 것처럼 보인다.
+ *
+ * 여러 층이 겹칠 수 있다. 시트 위에 사진 뷰어가 뜨면 둘 다 `popstate` 를
+ * 듣는데, 자기 번호가 히스토리에서 빠졌을 때만 닫는다. 그래서 뒤로가기
+ * 한 번에 맨 위 하나만 닫히고 아래는 남는다.
+ */
+export function useBackClose(isOpen: boolean, onClose: () => void) {
+  // 콜백이 매 렌더 새로 만들어져도 히스토리를 다시 쌓지 않게 최신 값만 들고 있는다.
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    layerSequence += 1;
+
+    const layerId = layerSequence;
+
+    history.pushState({ closableLayer: layerId }, '');
+
+    const handlePopState = () => {
+      // 내 항목이 아직 히스토리에 있으면 내 차례가 아니다.
+      if (getOpenLayerId() >= layerId) return;
+
+      onCloseRef.current();
+    };
+
+    window.addEventListener('popstate', handlePopState);
+
+    /*
+     * 정리할 때 쌓아둔 항목을 되돌리지 않는다.
+     *
+     * StrictMode 는 개발 모드에서 effect 를 한 번 더 돌린다. 여기서
+     * `history.back()` 을 부르면 그 뒤늦은 `popstate` 가 다시 마운트된 층을
+     * 닫아버려서, 사진을 누르자마자 깜빡이고 꺼진다.
+     *
+     * 대신 닫는 길을 `history.back()` 하나로 모아서 항목이 남지 않게 한다.
+     */
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [isOpen]);
+}

--- a/frontend/src/features/storeDetail/hooks/useRailDrag.ts
+++ b/frontend/src/features/storeDetail/hooks/useRailDrag.ts
@@ -9,6 +9,9 @@ import {
 /** 이만큼 끌어야 다음 장으로 넘어간다. 그보다 짧으면 제자리로 돌아온다. */
 const RAIL_SNAP_DISTANCE = 36;
 
+/** 이보다 적게 움직였으면 끈 게 아니라 누른 것으로 본다. */
+const TAP_SLOP = 6;
+
 interface RailDragStart {
   activeIndex: number;
   pointerId: number;
@@ -30,7 +33,16 @@ function getFrameScrollLeft(frame: HTMLElement, rail: HTMLElement) {
  *
  * 대표 사진과 가챠 사진이 같은 동작을 해야 해서 한 곳에 둔다.
  */
-export function useRailDrag(itemCount: number) {
+interface RailDragOptions {
+  /**
+   * 칸을 눌렀을 때. 레일이 포인터를 캡처하는 동안에는 안쪽 요소가 click 을
+   * 받지 못하므로, 끌린 거리로 눌림을 직접 가려낸다.
+   */
+  onTapItem?: (index: number) => void;
+}
+
+export function useRailDrag(itemCount: number, options: RailDragOptions = {}) {
+  const { onTapItem } = options;
   const railRef = useRef<HTMLDivElement>(null);
   const dragStartRef = useRef<RailDragStart | null>(null);
   const dragDistanceRef = useRef(0);
@@ -71,27 +83,33 @@ export function useRailDrag(itemCount: number) {
     return () => resizeObserver.disconnect();
   }, [itemCount, updateSlideControls]);
 
-  const scrollToIndex = useCallback(
-    (rail: HTMLElement, index: number) => {
+  const scrollRailToIndex = useCallback(
+    (rail: HTMLElement, index: number, behavior: ScrollBehavior = 'smooth') => {
       const nextIndex = Math.min(Math.max(index, 0), itemCount - 1);
       const nextFrame = rail.children.item(nextIndex) as HTMLElement | null;
 
       if (!nextFrame) return;
 
-      rail.scrollTo({
-        behavior: 'smooth',
-        left: getFrameScrollLeft(nextFrame, rail),
-      });
+      rail.scrollTo({ behavior, left: getFrameScrollLeft(nextFrame, rail) });
     },
     [itemCount],
+  );
+
+  /** 바깥에서 특정 장으로 보낼 때. 썸네일 줄과 처음 열 때 쓴다. */
+  const scrollToIndex = useCallback(
+    (index: number, behavior: ScrollBehavior = 'smooth') => {
+      const rail = railRef.current;
+
+      if (rail) scrollRailToIndex(rail, index, behavior);
+    },
+    [scrollRailToIndex],
   );
 
   const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.pointerType === 'mouse' && event.button !== 0) return;
 
-    // 레일이 포인터를 캡처하면 그 안의 버튼은 click 을 못 받는다.
-    // 눌린 곳이 버튼이면 끌기를 시작하지 않는다.
-    if ((event.target as HTMLElement).closest('button')) return;
+    // 레일 안의 조작 버튼은 스스로 click 을 받아야 한다. 끌기를 시작하지 않는다.
+    if ((event.target as HTMLElement).closest('[data-rail-control]')) return;
 
     dragStartRef.current = {
       activeIndex,
@@ -122,14 +140,31 @@ export function useRailDrag(itemCount: number) {
 
     if (!dragStart || dragStart.pointerId !== event.pointerId) return;
 
+    const dragDistance = dragDistanceRef.current;
     const direction =
-      Math.abs(dragDistanceRef.current) < RAIL_SNAP_DISTANCE
+      Math.abs(dragDistance) < RAIL_SNAP_DISTANCE
         ? 0
-        : dragDistanceRef.current > 0
+        : dragDistance > 0
           ? -1
           : 1;
 
-    scrollToIndex(event.currentTarget, dragStart.activeIndex + direction);
+    scrollRailToIndex(event.currentTarget, dragStart.activeIndex + direction);
+
+    if (Math.abs(dragDistance) < TAP_SLOP) {
+      const frames = Array.from(event.currentTarget.children) as HTMLElement[];
+      const tappedIndex = frames.findIndex((frame) => {
+        const rect = frame.getBoundingClientRect();
+
+        return (
+          event.clientX >= rect.left &&
+          event.clientX <= rect.right &&
+          event.clientY >= rect.top &&
+          event.clientY <= rect.bottom
+        );
+      });
+
+      if (tappedIndex !== -1) onTapItem?.(tappedIndex);
+    }
 
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId);
@@ -151,5 +186,6 @@ export function useRailDrag(itemCount: number) {
       onScroll: updateSlideControls,
     },
     railRef,
+    scrollToIndex,
   };
 }

--- a/frontend/src/features/storeDetail/hooks/useRailDrag.ts
+++ b/frontend/src/features/storeDetail/hooks/useRailDrag.ts
@@ -1,0 +1,155 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+
+/** 이만큼 끌어야 다음 장으로 넘어간다. 그보다 짧으면 제자리로 돌아온다. */
+const RAIL_SNAP_DISTANCE = 36;
+
+interface RailDragStart {
+  activeIndex: number;
+  pointerId: number;
+  scrollLeft: number;
+  x: number;
+}
+
+function getFrameScrollLeft(frame: HTMLElement, rail: HTMLElement) {
+  const firstFrame = rail.children.item(0) as HTMLElement | null;
+
+  return frame.offsetLeft - (firstFrame?.offsetLeft ?? 0);
+}
+
+/**
+ * 손가락으로 끌어 넘기는 가로 목록.
+ *
+ * 시트 자체가 위아래 드래그를 가로채기 때문에 브라우저 기본 스크롤에만
+ * 맡길 수 없다. 포인터를 직접 받아 어느 장에 멈출지 정한다.
+ *
+ * 대표 사진과 가챠 사진이 같은 동작을 해야 해서 한 곳에 둔다.
+ */
+export function useRailDrag(itemCount: number) {
+  const railRef = useRef<HTMLDivElement>(null);
+  const dragStartRef = useRef<RailDragStart | null>(null);
+  const dragDistanceRef = useRef(0);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const updateSlideControls = useCallback(() => {
+    const rail = railRef.current;
+
+    if (!rail) return;
+
+    const frames = Array.from(rail.children) as HTMLElement[];
+    const nextActiveIndex = frames.reduce((closestIndex, frame, index) => {
+      const closestFrame = frames[closestIndex];
+
+      if (!closestFrame) return index;
+
+      return Math.abs(getFrameScrollLeft(frame, rail) - rail.scrollLeft) <
+        Math.abs(getFrameScrollLeft(closestFrame, rail) - rail.scrollLeft)
+        ? index
+        : closestIndex;
+    }, 0);
+
+    setActiveIndex(nextActiveIndex);
+  }, []);
+
+  useEffect(() => {
+    const rail = railRef.current;
+
+    if (!rail) return;
+
+    updateSlideControls();
+
+    const resizeObserver = new ResizeObserver(updateSlideControls);
+
+    resizeObserver.observe(rail);
+
+    return () => resizeObserver.disconnect();
+  }, [itemCount, updateSlideControls]);
+
+  const scrollToIndex = useCallback(
+    (rail: HTMLElement, index: number) => {
+      const nextIndex = Math.min(Math.max(index, 0), itemCount - 1);
+      const nextFrame = rail.children.item(nextIndex) as HTMLElement | null;
+
+      if (!nextFrame) return;
+
+      rail.scrollTo({
+        behavior: 'smooth',
+        left: getFrameScrollLeft(nextFrame, rail),
+      });
+    },
+    [itemCount],
+  );
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+
+    // 레일이 포인터를 캡처하면 그 안의 버튼은 click 을 못 받는다.
+    // 눌린 곳이 버튼이면 끌기를 시작하지 않는다.
+    if ((event.target as HTMLElement).closest('button')) return;
+
+    dragStartRef.current = {
+      activeIndex,
+      pointerId: event.pointerId,
+      scrollLeft: event.currentTarget.scrollLeft,
+      x: event.clientX,
+    };
+    dragDistanceRef.current = 0;
+    setIsDragging(true);
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const dragStart = dragStartRef.current;
+
+    if (!dragStart || dragStart.pointerId !== event.pointerId) return;
+
+    const dragDistance = event.clientX - dragStart.x;
+
+    dragDistanceRef.current = dragDistance;
+    event.currentTarget.scrollLeft = dragStart.scrollLeft - dragDistance;
+
+    if (Math.abs(dragDistance) > 4) event.preventDefault();
+  };
+
+  const finishDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const dragStart = dragStartRef.current;
+
+    if (!dragStart || dragStart.pointerId !== event.pointerId) return;
+
+    const direction =
+      Math.abs(dragDistanceRef.current) < RAIL_SNAP_DISTANCE
+        ? 0
+        : dragDistanceRef.current > 0
+          ? -1
+          : 1;
+
+    scrollToIndex(event.currentTarget, dragStart.activeIndex + direction);
+
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+
+    dragStartRef.current = null;
+    dragDistanceRef.current = 0;
+    setIsDragging(false);
+  };
+
+  return {
+    activeIndex,
+    isDragging,
+    railProps: {
+      onPointerCancel: finishDrag,
+      onPointerDown: handlePointerDown,
+      onPointerMove: handlePointerMove,
+      onPointerUp: finishDrag,
+      onScroll: updateSlideControls,
+    },
+    railRef,
+  };
+}

--- a/frontend/src/features/storeDetail/hooks/useStoreDetailSheet.ts
+++ b/frontend/src/features/storeDetail/hooks/useStoreDetailSheet.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 
+import { useBackClose } from './useBackClose';
 import type { BottomSheetState } from '../model/storeDetail';
 
 export interface StorePinSelection {
@@ -29,6 +30,15 @@ export function useStoreDetailSheet() {
   const closeStoreDetail = useCallback(() => {
     setState('closed');
   }, []);
+
+  /**
+   * 웹이라 휴대폰 뒤로가기가 그대로 들어온다. 시트가 열린 채로 뒤로가기를 누르면
+   * 앱을 나가버리므로 시트를 먼저 닫는다.
+   *
+   * 사진 뷰어도 같은 훅을 쓴다. 나중에 연 쪽이 히스토리 위에 쌓이니
+   * 뷰어 → 시트 → 앱 순서로 닫힌다.
+   */
+  useBackClose(state !== 'closed', closeStoreDetail);
 
   /**
    * 지도의 빈 곳을 눌렀을 때. 시트를 첫 단계까지 내리고 매장 선택은 유지한다.


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->

매장 사진과 가챠 사진을 눌러 전체화면으로 볼 수 있게 했습니다.

- **사진 탭 → 전체화면 뷰어** — 상단 대표 사진, 가챠 미리보기 줄, 아래 가챠 전체 사진 그리드 어디서 눌러도 열립니다. 누른 그 장에서 시작합니다.
- **좌우로 넘기기** — 상세 시트의 사진 줄과 같은 드래그 조작을 씁니다.
- **아래 썸네일 줄** — 지금 몇 번째인지 보여주고, 눌러서 그 장으로 바로 갈 수 있습니다. 보고 있는 장은 항상 줄의 맨 왼쪽에 오도록 따라 움직입니다.
- **뒤로가기로 닫기** — 휴대폰 브라우저에서 뒤로가기를 누르면 뷰어만 닫히고 상세 시트는 남습니다. 한 번 더 누르면 시트가 닫힙니다.
- **닫는 방법** — X 버튼, `Esc`, 뒤로가기. 셋 다 같은 길로 닫힙니다.
- 뷰어가 떠 있는 동안 뒤 화면 스크롤을 잠급니다.

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #65 

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->

**After**
<img width="428" height="813" alt="image" src="https://github.com/user-attachments/assets/ab75ee9c-8457-47d1-8687-2c0c03bbad3a" />

<img width="432" height="814" alt="image" src="https://github.com/user-attachments/assets/4d19990a-fb55-4486-8f49-95657d33802f" />


## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->

**1. 뒤로가기 층 관리 (`useBackClose.ts`) — 여기를 제일 봐주세요**

층이 열릴 때 `history.pushState({ closableLayer: 번호 })`로 항목을 하나 쌓고, `popstate`에서 내 번호가 히스토리에서 사라졌을 때만 닫습니다. 시트 위에 뷰어가 겹쳐도 순서대로 하나씩 닫힙니다.

정리(cleanup)에서 `history.back()`을 **일부러 부르지 않습니다.** StrictMode가 개발 모드에서 effect를 한 번 더 돌리는데, 여기서 `back()`을 부르면 그 `popstate`가 비동기로 늦게 도착해서 이미 다시 마운트된 층을 닫아버립니다. 사진을 누르면 깜빡이고 꺼지는 증상이 이것이었습니다.

대신 개발 모드에서는 `pushState`가 두 번 되니 닫은 뒤 히스토리 항목이 하나 남습니다. **dev 빌드에서만** 뒤로가기 한 번이 씹힐 수 있고 프로덕션 빌드에서는 없습니다. 이보다 나은 방법이 있으면 알려주세요.

**2. 포털에서 이벤트 막기 (`PhotoViewer.tsx`의 `stopBubbling`)**

React는 포털 안의 이벤트를 DOM 트리가 아니라 **React 트리**를 따라 올립니다. 뷰어를 `document.body`에 붙여도 클릭과 포인터가 시트의 드래그 핸들러까지 올라가서, 아래 썸네일을 누르면 시트가 끌려 내려가 닫혀버렸습니다. 백드롭에서 포인터 계열 이벤트를 전부 막아 해결했습니다.

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [x] 포매터·린터를 통과했다
- [x] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다
