### PR TITLE
[REFACTOR] fake door 노출 조건을 가챠 이미지 존재여부로 변경 (#67)

### DIFF
--- a/frontend/src/features/storeDetail/analytics/gachaCatalogInterestAnalytics.ts
+++ b/frontend/src/features/storeDetail/analytics/gachaCatalogInterestAnalytics.ts
@@ -16,7 +16,7 @@ function captureGachaCatalogInterest(
   properties: Record<string, unknown> = {},
 ) {
   window.posthog?.capture(eventName, {
-    eligibility_reason: 'missing_instagram_and_gacha_images',
+    eligibility_reason: 'missing_gacha_images',
     environment: getEnvironment(),
     source: 'store_detail_gacha_tab',
     store_id: storeId,

--- a/frontend/src/features/storeDetail/components/StoreDetailSheet.stories.tsx
+++ b/frontend/src/features/storeDetail/components/StoreDetailSheet.stories.tsx
@@ -9,10 +9,9 @@ import { mockStoreImages } from '../mocks/storePhotos.mock';
 import { toStoreDetail } from '../model/toStoreDetail';
 
 const store = toStoreDetail(mockStoreDetail, { distanceMeters: 380 });
-const storeWithoutGachaSource = toStoreDetail(
+const storeWithInstagramWithoutGachaImages = toStoreDetail(
   {
     ...mockStoreDetail,
-    instagramId: null,
     storeId: 55,
   },
   {
@@ -122,12 +121,12 @@ export const GalleryWithGachaImages: Story = {
   ),
 };
 
-export const GachaInterestFakeDoor: Story = {
+export const GachaInterestWithInstagram: Story = {
   render: () => (
     <StoreDetailSheet
       state="full"
       status="success"
-      store={storeWithoutGachaSource}
+      store={storeWithInstagramWithoutGachaImages}
       onClose={doNothing}
       onStateChange={doNothing}
     />

--- a/frontend/src/features/storeDetail/model/isGachaCatalogInterestEligible.ts
+++ b/frontend/src/features/storeDetail/model/isGachaCatalogInterestEligible.ts
@@ -1,18 +1,7 @@
 import type { StoreDetail } from './storeDetail';
 
 export function isGachaCatalogInterestEligible(
-  store: Pick<
-    StoreDetail,
-    'gachaImageUrls' | 'isGachaCatalogLoaded' | 'socialLinks'
-  >,
+  store: Pick<StoreDetail, 'gachaImageUrls' | 'isGachaCatalogLoaded'>,
 ) {
-  const hasInstagram = store.socialLinks.some(
-    ({ platform }) => platform === 'instagram',
-  );
-
-  return (
-    store.isGachaCatalogLoaded &&
-    store.gachaImageUrls.length === 0 &&
-    !hasInstagram
-  );
+  return store.isGachaCatalogLoaded && store.gachaImageUrls.length === 0;
 }


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->

- fake door 노출 조건에서 인스타그램 계정 유무 조건을 제거
- 가챠 이미지 조회가 정상적으로 완료되었고 이미지가 없는 모든 매장에 fake door가 노출되도록 변경
- 가챠 이미지 조회 실패 시 fake door가 노출되지 않도록 기존 조회 성공 조건을 유지
- 인스타그램 계정은 있지만 가챠 이미지가 없는 매장의 fake door 노출을 확인할 수 있도록 Storybook 사례를 수정

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #67 

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->

## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->
- fake door의 노출 기준이 인스타그램 계정 유무와 분리되고, 가챠 이미지 존재 여부만 반영하도록 변경
- 가챠 이미지 API 조회 실패를 이미지 없음으로 간주하지 않도록 `isGachaCatalogLoaded` 조건은 유지

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [x] 포매터·린터를 통과했다
- [x] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다
