### PR TITLE
[FEAT] 지도 중심 기준 매장 재검색 기능 추가

### DIFF
--- a/frontend/src/components/kakaoMap/KakaoMap.tsx
+++ b/frontend/src/components/kakaoMap/KakaoMap.tsx
@@ -14,6 +14,8 @@ interface KakaoMapProps {
   onMapReady?: (map: kakao.maps.Map) => void;
   /** 지도의 빈 곳을 눌렀을 때. 마커를 누른 경우에는 호출되지 않는다. */
   onMapClick?: () => void;
+  /** 사용자가 지도 드래그를 마쳤을 때. 프로그램으로 지도를 옮긴 경우에는 호출되지 않는다. */
+  onMapDragEnd?: () => void;
   children?: ReactNode;
 }
 
@@ -22,16 +24,19 @@ export default function KakaoMap({
   defaultLevel = 4,
   onMapReady,
   onMapClick,
+  onMapDragEnd,
   children,
 }: KakaoMapProps) {
   const kakaoMap = useKakaoMap({ defaultCenter, defaultLevel });
   const map = kakaoMap.status === 'success' ? kakaoMap.data : null;
   const onMapReadyRef = useRef(onMapReady);
   const onMapClickRef = useRef(onMapClick);
+  const onMapDragEndRef = useRef(onMapDragEnd);
 
   useEffect(() => {
     onMapReadyRef.current = onMapReady;
     onMapClickRef.current = onMapClick;
+    onMapDragEndRef.current = onMapDragEnd;
   });
 
   useEffect(() => {
@@ -46,10 +51,15 @@ export default function KakaoMap({
 
     const { maps } = window.kakao;
     const handleClick = () => onMapClickRef.current?.();
+    const handleDragEnd = () => onMapDragEndRef.current?.();
 
     maps.event.addListener(map, 'click', handleClick);
+    maps.event.addListener(map, 'dragend', handleDragEnd);
 
-    return () => maps.event.removeListener(map, 'click', handleClick);
+    return () => {
+      maps.event.removeListener(map, 'click', handleClick);
+      maps.event.removeListener(map, 'dragend', handleDragEnd);
+    };
   }, [map]);
 
   return (

--- a/frontend/src/features/storeDetail/hooks/useStoreDetailSheet.ts
+++ b/frontend/src/features/storeDetail/hooks/useStoreDetailSheet.ts
@@ -31,6 +31,13 @@ export function useStoreDetailSheet() {
     setState('closed');
   }, []);
 
+  /** 닫기용 히스토리 항목을 먼저 제거하고 popstate에서 실제 상태를 닫는다. */
+  const requestCloseStoreDetail = useCallback(() => {
+    if (state === 'closed') return;
+
+    history.back();
+  }, [state]);
+
   /**
    * 웹이라 휴대폰 뒤로가기가 그대로 들어온다. 시트가 열린 채로 뒤로가기를 누르면
    * 앱을 나가버리므로 시트를 먼저 닫는다.
@@ -77,6 +84,7 @@ export function useStoreDetailSheet() {
     collapseStoreDetail,
     isStoreOpen,
     openStoreDetail,
+    requestCloseStoreDetail,
     selectStoreDetail,
     selection,
     setState,

--- a/frontend/src/mocks/MockedStoreList.stories.tsx
+++ b/frontend/src/mocks/MockedStoreList.stories.tsx
@@ -7,15 +7,23 @@ import {
   type NearbyStore,
 } from '@/apis/store';
 
-function MockedStoreList() {
+interface MockedStoreListProps {
+  latitude: number;
+  longitude: number;
+}
+
+function MockedStoreList({ latitude, longitude }: MockedStoreListProps) {
   const [stores, setStores] = useState<NearbyStore[] | null>(null);
   const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
 
+    setStores(null);
+    setHasError(false);
+
     getNearbyStores(
-      { latitude: 37.5551, longitude: 126.9251, radius: DEFAULT_RADIUS },
+      { latitude, longitude, radius: DEFAULT_RADIUS },
       controller.signal,
     )
       .then((data) => setStores(data.stores))
@@ -28,7 +36,7 @@ function MockedStoreList() {
       });
 
     return () => controller.abort();
-  }, []);
+  }, [latitude, longitude]);
 
   if (hasError) {
     return <p role="alert">매장 목록을 불러오지 못했습니다.</p>;
@@ -52,6 +60,10 @@ function MockedStoreList() {
 const meta = {
   title: 'Mocks/Store list',
   component: MockedStoreList,
+  args: {
+    latitude: 37.5551,
+    longitude: 126.9251,
+  },
 } satisfies Meta<typeof MockedStoreList>;
 
 export default meta;
@@ -59,3 +71,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Success: Story = {};
+
+export const InternationalElectronicsCenter: Story = {
+  args: {
+    latitude: 37.4847435,
+    longitude: 127.0178182,
+  },
+};

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -17,29 +17,75 @@ import {
   storeFrontPhoto,
 } from '@/features/storeDetail/mocks/storePhotos.mock';
 
-export const mockNearbyStores: NearbyStore[] = [
+type MockStoreLocation = Omit<NearbyStore, 'distance'>;
+
+const EARTH_RADIUS_METERS = 6_371_000;
+
+const mockStoreLocations: MockStoreLocation[] = [
   {
     storeId: 2,
     thumbnailUrl: '',
     latitude: 37.5559645111431,
     longitude: 126.923901713362,
-    distance: 145,
   },
   {
     storeId: 1,
     thumbnailUrl: '',
     latitude: 37.556674962258,
     longitude: 126.925336052306,
-    distance: 180,
   },
   {
     storeId: 3,
     thumbnailUrl: '',
     latitude: 37.5569164654944,
     longitude: 126.925392965,
-    distance: 207,
+  },
+  {
+    storeId: 4,
+    thumbnailUrl: '',
+    latitude: 37.4847435,
+    longitude: 127.0178182,
   },
 ];
+
+function toRadians(degrees: number) {
+  return (degrees * Math.PI) / 180;
+}
+
+function getDistanceMeters(
+  latitude: number,
+  longitude: number,
+  store: MockStoreLocation,
+) {
+  const latitudeDelta = toRadians(store.latitude - latitude);
+  const longitudeDelta = toRadians(store.longitude - longitude);
+  const originLatitude = toRadians(latitude);
+  const storeLatitude = toRadians(store.latitude);
+  const haversine =
+    Math.sin(latitudeDelta / 2) ** 2 +
+    Math.cos(originLatitude) *
+      Math.cos(storeLatitude) *
+      Math.sin(longitudeDelta / 2) ** 2;
+
+  return Math.round(
+    2 *
+      EARTH_RADIUS_METERS *
+      Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine)),
+  );
+}
+
+function getMockNearbyStores(
+  latitude: number,
+  longitude: number,
+  radius: number,
+) {
+  return mockStoreLocations
+    .map((store): NearbyStore => ({
+      ...store,
+      distance: getDistanceMeters(latitude, longitude, store),
+    }))
+    .filter((store) => store.distance <= radius);
+}
 
 const withImages = (imageUrls: string[]) =>
   imageUrls.map((imageUrl, index) => ({
@@ -66,6 +112,14 @@ const mockStoreDetails: Record<number, StoreDetailDto> = {
     thumbnailUrl: machinePhoto,
     images: withImages([machinePhoto, entrancePhoto]),
   },
+  4: {
+    ...mockStoreDetail,
+    storeId: 4,
+    name: '국제전자센터 가챠샵',
+    address: '서울 서초구 효령로 304',
+    thumbnailUrl: storeFrontPhoto,
+    images: withImages(mockStoreImages),
+  },
 };
 
 export const handlers = [
@@ -81,7 +135,7 @@ export const handlers = [
       data: {
         center: { latitude, longitude },
         radius,
-        stores: mockNearbyStores.filter((store) => store.distance <= radius),
+        stores: getMockNearbyStores(latitude, longitude, radius),
       },
     });
   }),

--- a/frontend/src/pages/Map.tsx
+++ b/frontend/src/pages/Map.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 
 import type { NearbyStoresFailure } from '@/apis/store';
@@ -12,7 +12,19 @@ import {
   StoreDetailSheetContainer,
   useStoreDetailSheet,
 } from '@/features/storeDetail';
-import { useNearbyStores } from '@/hooks/useNearbyStores';
+import {
+  useNearbyStores,
+  type NearbyStoresState,
+} from '@/hooks/useNearbyStores';
+import {
+  alpha,
+  color,
+  focusRing,
+  fontSize,
+  fontWeight,
+  radius,
+  shadow,
+} from '@/styles/tokens';
 
 const DEFAULT_CENTER = { lat: 37.5550659903951, lng: 126.925097731352 };
 
@@ -21,15 +33,59 @@ const STORE_ERROR_MESSAGE: Record<NearbyStoresFailure, string> = {
   server: '매장 정보를 불러오지 못했습니다.',
 };
 
+interface MapSearchOverlayProps {
+  hasSearchAreaChanged: boolean;
+  onRetry: () => void;
+  onSearch: () => void;
+  state: NearbyStoresState;
+}
+
+function MapSearchOverlay({
+  hasSearchAreaChanged,
+  onRetry,
+  onSearch,
+  state,
+}: MapSearchOverlayProps) {
+  if (state.status === 'loading') {
+    return <StatusBar role="status">주변 매장을 불러오는 중입니다.</StatusBar>;
+  }
+
+  if (hasSearchAreaChanged) {
+    return (
+      <SearchAreaButton type="button" onClick={onSearch}>
+        이 지역에서 재검색
+      </SearchAreaButton>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <StoreErrorNotice
+        message={STORE_ERROR_MESSAGE[state.error]}
+        onRetry={onRetry}
+      />
+    );
+  }
+
+  if (state.data.length === 0) {
+    return <StatusBar role="status">주변에 매장이 없습니다.</StatusBar>;
+  }
+
+  return null;
+}
+
 export default function MapPage() {
+  const [searchCenter, setSearchCenter] = useState(DEFAULT_CENTER);
+  const [hasSearchAreaChanged, setHasSearchAreaChanged] = useState(false);
   const nearbyStores = useNearbyStores({
-    latitude: DEFAULT_CENTER.lat,
-    longitude: DEFAULT_CENTER.lng,
+    latitude: searchCenter.lat,
+    longitude: searchCenter.lng,
   });
   const {
     closeStoreDetail,
     collapseStoreDetail,
     isStoreOpen,
+    requestCloseStoreDetail,
     selectStoreDetail,
     selection,
     setState,
@@ -39,6 +95,17 @@ export default function MapPage() {
   const mapRef = useRef<kakao.maps.Map | null>(null);
 
   const stores = nearbyStores.status === 'success' ? nearbyStores.data : [];
+
+  const handleSearchCurrentArea = useCallback(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const center = map.getCenter();
+
+    requestCloseStoreDetail();
+    setSearchCenter({ lat: center.getLat(), lng: center.getLng() });
+    setHasSearchAreaChanged(false);
+  }, [requestCloseStoreDetail]);
 
   /** 마커를 눌러 시트가 열릴 때, 그 마커가 시트에 가리면 지도를 옮겨준다. */
   const handleMarkerClick = useCallback(
@@ -63,6 +130,7 @@ export default function MapPage() {
       <KakaoMap
         defaultCenter={DEFAULT_CENTER}
         onMapClick={collapseStoreDetail}
+        onMapDragEnd={() => setHasSearchAreaChanged(true)}
         onMapReady={(map) => {
           mapRef.current = map;
         }}
@@ -83,20 +151,12 @@ export default function MapPage() {
         })}
       </KakaoMap>
 
-      {nearbyStores.status === 'loading' && (
-        <StatusBar>주변 매장을 불러오는 중입니다.</StatusBar>
-      )}
-
-      {nearbyStores.status === 'error' && (
-        <StoreErrorNotice
-          message={STORE_ERROR_MESSAGE[nearbyStores.error]}
-          onRetry={nearbyStores.retry}
-        />
-      )}
-
-      {nearbyStores.status === 'success' && stores.length === 0 && (
-        <StatusBar>주변에 매장이 없습니다.</StatusBar>
-      )}
+      <MapSearchOverlay
+        hasSearchAreaChanged={hasSearchAreaChanged}
+        state={nearbyStores}
+        onRetry={nearbyStores.retry}
+        onSearch={handleSearchCurrentArea}
+      />
 
       <StoreDetailSheetContainer
         distanceMeters={selection?.distanceMeters}
@@ -122,10 +182,10 @@ const floatingBar = `
   left: 50%;
   transform: translateX(-50%);
   z-index: 10;
-  border-radius: 20px;
-  background-color: rgb(0 0 0 / 70%);
-  color: #fff;
-  font-size: 13px;
+  border-radius: ${radius.pill};
+  background-color: ${alpha(color.ink, 70)};
+  color: ${color.surface};
+  font-size: ${fontSize.sm};
   white-space: nowrap;
 `;
 
@@ -133,6 +193,24 @@ const StatusBar = styled.p`
   ${floatingBar}
   margin: 0;
   padding: 8px 16px;
+`;
+
+const SearchAreaButton = styled.button`
+  ${floatingBar}
+  min-height: 44px;
+  padding: 10px 18px;
+  border: 1px solid ${color.line};
+  background-color: ${color.surface};
+  box-shadow: ${shadow.float};
+  color: ${color.ink};
+  font-family: inherit;
+  font-weight: ${fontWeight.bold};
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: ${focusRing};
+    outline-offset: 2px;
+  }
 `;
 
 const StoreErrorNotice = styled(ErrorNotice)`


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->

- 기존 홍대 고정 좌표를 최초 검색 중심으로만 사용하도록 변경
- 사용자가 지도를 드래그하면 `이 지역에서 재검색` 버튼이 나타나도록 구현
- 버튼 클릭 시 현재 지도 중심 좌표를 기준으로 반경 3km 내 매장 목록을 다시 조회
- 로딩, 오류, 빈 결과, 재검색 상태가 동시에 노출되지 않도록 검색 오버레이를 구성
- 재검색 시 열린 매장 상세 시트를 브라우저 히스토리와 함께 닫도록 처리
- Kakao 지도 이벤트 리스너 등록과 해제 책임을 `KakaoMap` 내부에 유지
- 검색 중심 기준 거리를 계산하는 MSW 핸들러와 국제전자센터 Storybook 시나리오를 추가

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #73 

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->

## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->

- 자동 검색이 아닌 명시적인 재검색 버튼을 사용해 지도 이동 중 반복 API 호출을 방지
- `idle` 이벤트는 마커 클릭에 따른 프로그램 이동에도 발생할 수 있어 사용자 드래그만 감지하는 `dragend`를 사용
- 검색 기준은 GPS 현재 위치가 아닌 지도 중심
- 현재 API 계약에 맞춰 지도 중심 기준 고정 3km 반경으로 검색합니다. 정확한 화면 경계 기반 검색은 이번 범위에 포함하지 않음에 주의
- 상세 시트가 열린 상태에서 재검색할 때 시트용 히스토리가 남지 않도록 `history.back()` 기반 닫기 경로를 추가
- API가 반환하는 `distance`는 사용자 위치가 아닌 검색 중심 기준 거리로 유지

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [x] 포매터·린터를 통과했다
- [x] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다
