### PR TITLE
[REFACTOR] 매장 호수 정보 배열 변환

### DIFF
--- a/backend/src/main/java/com/gachi/gacha/server/store/presentation/dto/StoreNearbyResponse.java
+++ b/backend/src/main/java/com/gachi/gacha/server/store/presentation/dto/StoreNearbyResponse.java
@@ -1,6 +1,7 @@
 package com.gachi.gacha.server.store.presentation.dto;
 
 import com.gachi.gacha.server.store.application.dto.StoreNearbyResult;
+import java.util.Arrays;
 import java.util.List;
 
 public record StoreNearbyResponse(
@@ -37,7 +38,7 @@ public record StoreNearbyResponse(
             String thumbnailUrl,
             String address,
             Integer floor,
-            String unit,
+            List<String> unit,
             Double latitude,
             Double longitude,
             Double distance
@@ -50,11 +51,22 @@ public record StoreNearbyResponse(
                     store.thumbnailUrl(),
                     store.address(),
                     store.floor(),
-                    store.unit(),
+                    parseUnits(store.unit()),
                     store.latitude(),
                     store.longitude(),
                     store.distance()
             );
+        }
+
+        private static List<String> parseUnits(final String unit) {
+            if (unit == null || unit.isBlank()) {
+                return List.of();
+            }
+
+            return Arrays.stream(unit.split(","))
+                    .map(String::trim)
+                    .filter(value -> !value.isBlank())
+                    .toList();
         }
     }
 }

--- a/backend/src/test/java/com/gachi/gacha/server/store/presentation/StoreControllerTest.java
+++ b/backend/src/test/java/com/gachi/gacha/server/store/presentation/StoreControllerTest.java
@@ -191,9 +191,13 @@ class StoreControllerTest {
                     .extract();
 
             // then
+            List<Long> storeIds = response.jsonPath().getList("data.stores.storeId", Long.class);
+            int storeIndex = storeIds.indexOf(storeId);
+
             assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
             assertThat(response.jsonPath().getString("code")).isEqualTo("C000");
-            assertThat(response.jsonPath().getList("data.stores.storeId", Long.class)).contains(storeId);
+            assertThat(storeIds).contains(storeId);
+            assertThat(response.jsonPath().getList("data.stores[" + storeIndex + "].unit", String.class)).isEmpty();
             assertThat(response.jsonPath().getDouble("data.stores[0].distance")).isZero();
         }
 
@@ -221,8 +225,8 @@ class StoreControllerTest {
             // given
             double latitude = 37.484742019735;
             double longitude = 127.01776766049;
-            Long floor7StoreId = createTargetStore("7층 매장", latitude, longitude, 7, "92호");
-            Long floor8StoreId = createTargetStore("8층 매장", latitude, longitude, 8, "99호");
+            Long floor7StoreId = createTargetStore("7층 매장", latitude, longitude, 7, "7092, 7093");
+            Long floor8StoreId = createTargetStore("8층 매장", latitude, longitude, 8, "8099");
             Long unknownFloorStoreId = createTargetStore("층 미상 매장", latitude, longitude);
 
             // when
@@ -245,7 +249,8 @@ class StoreControllerTest {
             assertThat(response.jsonPath().getString("data.stores[" + storeIndex + "].address"))
                     .isEqualTo(STORE_ADDRESS);
             assertThat(response.jsonPath().getInt("data.stores[" + storeIndex + "].floor")).isEqualTo(7);
-            assertThat(response.jsonPath().getString("data.stores[" + storeIndex + "].unit")).isEqualTo("92호");
+            assertThat(response.jsonPath().getList("data.stores[" + storeIndex + "].unit", String.class))
+                    .containsExactly("7092", "7093");
         }
 
         @Test


### PR DESCRIPTION
## 작업 내용
<!-- 이번 PR에서 구현/수정한 내용을 간단히 설명해주세요. -->

## 관련 이슈
<!-- 이슈 번호는 커밋이 아니라 여기, PR에서만 연결합니다.
   닫을 이슈가 여러 개면 키워드를 줄바꿈해서 각각 반복해주세요.
   예)
   Closes #12
   Closes #13
-->

Closes #79 

## 스크린샷 (프론트엔드 변경 시)
<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요. -->

## 리뷰 포인트
<!-- 특히 봐줬으면 하는 부분이나 고민한 지점 -->

매장 조회 시 세부 정보 관련 DTO에서 unit 필드를 List<Integer>로 수정하고,
이를 파싱하는 메서드 추가했습니다 

## 체크리스트
- [x] 작업전에 pull.. 하셨나요? 
- [x] 브랜치명에 이슈 번호가 들어갔다
- [x] 내 포지션 폴더(`frontend/` 또는 `backend/`)만 수정했다
- [x] 로컬에서 실행·빌드·테스트가 정상 동작한다
- [ ] 포매터·린터를 통과했다
- [ ] 디버깅용 코드를 지웠다 (`console.log`, `System.out.println`)
- [x] 커밋 메시지가 컨벤션에 맞다
